### PR TITLE
Allow Prometheus/TSDB blocks from multiple sources

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -5,6 +5,7 @@ services:
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.retention.time=1y'
+      - '--storage.tsdb.allow-overlapping-blocks'
     ports:
       - 9090:9090
     restart: unless-stopped


### PR DESCRIPTION
Adds flag to Prometheus that enables vertical compaction and makes it possible to copy data from multiple Prometheus instances without manually rewriting the database: simply copy blocks from one Prometheus data directory to the target Prometheus data directory.

For example, Prometheus data directories usually look like this:
```
01HQAK3HN2YAJ8XJPB3B5P88XX/
01HQBW9EBQEANHPGTEP5YDF5D0/ 
01HQC355KQ5V8WPCFKA3DJ8E9H/
chunks_head/
queries.active 
wal/
```
In this case the first 3 subdirectories starting with `01HQ*` are blocks that have been compacted.

The main caveat is this works well enough for already compacted TSDB blocks, but it doesn't work for the _head block_ (the block that holds the most recent data), and so there is a chance we are losing the last ~2 hours of the Prometheus databases we are merging.

It would be ideal if we can simply flush the _head block_ with the Prometheus API or with promtool. There are a number of proposals, but nothing that looks like it has made it to Prometheus yet.

Alternatives I'm thinking of are playing with snapshots to force writing the _head block_, or forcing it directly with a custom tool that calls `FlushWAL()` on the Prometheus database.

While not perfect, this approach to combining multiple Prometheus databases is more promising than anything else I've seen so far.