### PR TITLE
Avoid using hardcoded ROCm version

### DIFF
--- a/collector_rocm_smi.py
+++ b/collector_rocm_smi.py
@@ -49,14 +49,13 @@ from collector_base import Collector
 from prometheus_client import Gauge, generate_latest, CollectorRegistry
 
 class ROCMSMI(Collector):
-    def __init__(self,rocm_smi_binary=None):
+    def __init__(self,rocm_path="/opt/rocm"):
         logging.debug("Initializing ROCm SMI data collector")
         self.__prefix = "rocm_"
 
         # setup rocm-smi path
-        if rocm_smi_binary:
-            command = rocm_smi_binary
-        else:
+        command = rocm_path + "/bin/rocm-smi"
+        if not os.path.isfile(command):
             command = utils.resolvePath("rocm-smi", "ROCM_SMI_PATH")
 
         # command-line flags for use with rocm-smi to obtained desired metrics

--- a/collector_smi.py
+++ b/collector_smi.py
@@ -58,13 +58,12 @@ rsmi_clk_names_dict = {'sclk': 0x0, 'fclk': 0x1, 'dcefclk': 0x2,\
 #--
 
 class ROCMSMI(Collector):
-    def __init__(self,rocm_smi_binary=None):
+    def __init__(self,rocm_path="/opt/rocm"):
         logging.debug("Initializing ROCm SMI data collector")
         self.__prefix = "rocm_"
 
         # load smi runtime
-        rocm_lib = "/opt/rocm-5.7.1/lib"
-        self.__libsmi = ctypes.CDLL(rocm_lib + "/librocm_smi64.so")
+        self.__libsmi = ctypes.CDLL(rocm_path + "/lib/librocm_smi64.so")
         logging.info("Runtime library loaded")
 
         # initialize smi library

--- a/monitor.py
+++ b/monitor.py
@@ -66,12 +66,11 @@ class Monitor():
             self.runtimeConfig['slurm_collector_annotations'] = config['omniwatch.collectors.slurm'].getboolean('enable_annotations',False)
             self.runtimeConfig['collector_port'] = config['omniwatch.collectors'].get('port',8000)
             self.runtimeConfig['collector_usermode'] = config['omniwatch.collectors'].getboolean('usermode',False)
+            self.runtimeConfig['collector_rocm_path'] = config['omniwatch.collectors'].get('rocm_path','/opt/rocm')
 
             # optional runtime controls
             if config.has_option('omniwatch.collectors.slurm','host_skip'):
                 self.runtimeConfig['slurm_collector_host_skip'] = config['omniwatch.collectors.slurm']['host_skip']
-            if config.has_option('omniwatch.collectors','smi_binary'):
-                self.runtimeConfig['rocm_smi_binary'] = config['omniwatch.collectors']['smi_binary']
 
         else:
             utils.error("Unable to find runtime config file %s" % configFile)
@@ -102,10 +101,7 @@ class Monitor():
 
         if self.runtimeConfig['collector_enable_rocm_smi']:
             from collector_smi import ROCMSMI
-            binary = None
-            if 'rocm_smi_binary' in self.runtimeConfig:
-                binary = self.runtimeConfig['rocm_smi_binary']
-            self.__collectors.append(ROCMSMI(rocm_smi_binary=binary))
+            self.__collectors.append(ROCMSMI(rocm_path=self.runtimeConfig['collector_rocm_path']))
         if self.runtimeConfig['collector_enable_slurm']:
             from collector_slurm import SlurmJob
             self.__collectors.append(SlurmJob(userMode=self.runtimeConfig['collector_usermode'],

--- a/omniwatch.default
+++ b/omniwatch.default
@@ -8,6 +8,7 @@ enable_rocm_smi = True
 enable_slurm = True
 corebinding = 31
 logfile = exporter.log
+rocm_path = /opt/rocm
 
 [omniwatch.collectors.slurm]
 

--- a/omniwatch.ornl
+++ b/omniwatch.ornl
@@ -11,6 +11,7 @@ enable_rocm_smi = True
 enable_slurm = True
 corebinding = 31
 logfile = exporter.log
+rocm_path = /opt/rocm-default
 
 [omniwatch.collectors.slurm]
 


### PR DESCRIPTION
I ran into issues installing omniwatch in a cluster because we are using a specific ROCm version and path in the SMI collector. With this change, the SMI collector will now attempt to read the ROCM_PATH environment variable, or simply default to "/opt/rocm" if the variable is not defined.

I decided to use the environment variable to keep the changes small. It may be more desirable to have a "rocm_path" option in the configuration file instead. (I didn't want to pollute the constructor of the collectors with another optional variable, but if we are not going to keep the rocm-smi collector, we can get rid of the "rocm_smi_binary" option and simply pass "rocm_path" or something similar.)