### PR TITLE
Fix version when package is not installed

### DIFF
--- a/omnistat/utils.py
+++ b/omnistat/utils.py
@@ -263,7 +263,14 @@ def removeQuotes(input):
 
 def getVersion():
     """Return omnistat version info"""
-    return version('omnistat')
+    try:
+        return version('omnistat')
+    except importlib.metadata.PackageNotFoundError:
+        # When package is not installed, rely on setuptools-git-versioning
+        # to figure out the version; use the executable because the internal
+        # API is not guaranteed to remain compatible.
+        result = runShellCommand("setuptools-git-versioning")
+        return result.stdout.strip()
 
 
 def displayVersion(version):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ prometheus_client>=0.17.0
 gunicorn>=21.2.0
 packaging>=24.1
 parallel-ssh>=2.12.0
+setuptools-git-versioning>=2.0,<3


### PR DESCRIPTION
In order to have the same version in installed and uninstalled executions, we need to turn setuptools-git-versioning into a dependency (and not just build dependency).

