### PR TITLE
Alternative counter collection with rocprofiler

### DIFF
--- a/omnistat/collector_rocprofiler.py
+++ b/omnistat/collector_rocprofiler.py
@@ -10,7 +10,7 @@ from omnistat.collector_base import Collector
 
 class rocprofiler_counter_value_t(ctypes.Structure):
     _fields_ = [
-        ("value", ctypes.c_uint64),
+        ("value", ctypes.c_double),
     ]
 
 

--- a/omnistat/collector_rocprofiler.py
+++ b/omnistat/collector_rocprofiler.py
@@ -1,0 +1,116 @@
+import ctypes
+import logging
+import os
+import sys
+
+from prometheus_client import Gauge, generate_latest
+
+from omnistat.collector_base import Collector
+
+
+class rocprofiler_counter_value_t(ctypes.Structure):
+    _fields_ = [
+        ("value", ctypes.c_uint64),
+    ]
+
+
+class rocprofiler_device_profile_metric_t(ctypes.Structure):
+    _fields_ = [
+        ("metric_name", ctypes.c_char * 64),
+        ("value", rocprofiler_counter_value_t),
+    ]
+
+
+class rocprofiler_session_id_t(ctypes.Structure):
+    _fields_ = [
+        ("handle", ctypes.c_uint64),
+    ]
+
+
+class rocprofiler(Collector):
+    def __init__(self, rocm_path, metric_names):
+        logging.debug("Initializing rocprofiler data collector")
+
+        hip_lib = rocm_path + "/lib/libamdhip64.so"
+        rocprofiler_lib = rocm_path + "/lib/librocprofiler64v2.so"
+
+        if not os.path.isfile(hip_lib):
+            logging.error("ERROR: Unable to load HIP library.")
+            logging.error("--> looking for %s" % hip_lib)
+            sys.exit(4)
+
+        if not os.path.isfile(rocprofiler_lib):
+            logging.error("ERROR: Unable to load rocprofiler library.")
+            logging.error("--> looking for %s" % rocprofiler_lib)
+            sys.exit(4)
+
+        self.__libhip = ctypes.CDLL(hip_lib)
+        self.__librocprofiler = ctypes.CDLL(rocprofiler_lib)
+
+        logging.info("Runtime library loaded from %s" % hip_lib)
+        logging.info("Runtime library loaded from %s" % rocprofiler_lib)
+
+        num_gpus = (ctypes.c_int)()
+        status = self.__libhip.hipGetDeviceCount(ctypes.byref(num_gpus))
+        assert status == 0
+        status = self.__librocprofiler.rocprofiler_initialize()
+        assert status == 0
+        logging.info("rocprofiler library API initialized")
+
+        self.__num_gpus = num_gpus.value
+        self.__names = metric_names
+
+        # List of Prometheus gauges, one for each metric
+        self.__metrics = []
+
+        # Lists indexed by GPU ID:
+        #  __sessions: stores rocprofiler device mode sessions
+        #  __values: stores arrays of values returned by rocprofiler
+        self.__sessions = []
+        self.__values = []
+
+        for i in range(self.__num_gpus):
+            self.__sessions.append((rocprofiler_session_id_t)())
+            self.__values.append((rocprofiler_device_profile_metric_t * len(self.__names))())
+
+        logging.info(f"--> rocprofiler: number of GPUs detected = {self.__num_gpus}")
+        logging.info(f"--> rocprofiler: metrics = {self.__names}")
+
+        # Convert list of metrics to pass with ctypes
+        names_bytes = [bytes(i, "utf-8") for i in self.__names]
+        names_array = (ctypes.c_char_p * len(names_bytes))()
+        names_array[:] = names_bytes
+
+        # Create rocprofiler sessions for each GPU
+        for i in range(self.__num_gpus):
+            self.__librocprofiler.rocprofiler_device_profiling_session_create(
+                names_array, len(names_array), ctypes.byref(self.__sessions[i]), 0, i
+            )
+
+        logging.info("--> rocprofiler initialized")
+
+    def registerMetrics(self):
+        prefix = f"rocprofiler_"
+        for metric in self.__names:
+            metric_name = prefix + metric
+            self.__metrics.append(Gauge(metric_name, "", labelnames=["card"]))
+            logging.info("--> [registered] %s (gauge)" % (metric_name))
+
+        for i in range(self.__num_gpus):
+            self.__librocprofiler.rocprofiler_device_profiling_session_start(self.__sessions[i])
+
+    def updateMetrics(self):
+        for i in range(self.__num_gpus):
+            self.__librocprofiler.rocprofiler_device_profiling_session_poll(self.__sessions[i], self.__values[i])
+
+            # Reset sessions to address issues with values (SWDEV-468600)
+            self.__librocprofiler.rocprofiler_device_profiling_session_stop(self.__sessions[i])
+            self.__librocprofiler.rocprofiler_device_profiling_session_start(self.__sessions[i])
+
+        for i in range(self.__num_gpus):
+            for j in range(len(self.__names)):
+                array = self.__values[i]
+                value = array[j].value.value
+                self.__metrics[j].labels(card=i).set(value)
+
+        return

--- a/omnistat/collector_rocprofiler.py
+++ b/omnistat/collector_rocprofiler.py
@@ -1,3 +1,42 @@
+# -------------------------------------------------------------------------------
+# MIT License
+#
+# Copyright (c) 2023 - 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# -------------------------------------------------------------------------------
+
+"""Hardware counter collection using device mode with rocprofiler
+
+Implements collection of user-requested hardware counters. The ROCm
+runtime must be pre-installed to use this data collector. This data
+collector gathers counters on a per GPU basis and exposes metrics
+with a "rocprofiler" prefix with individual cards denotes by labels. The
+following example highlights example metrics for card 0:
+
+rocprofiler_SQ_WAVES{card="0"} 0.0
+rocprofiler_SQ_INSTS{card="0"} 0.0
+rocprofiler_TOTAL_64_OPS{card="0"} 0.0
+rocprofiler_SQ_INSTS_VALU{card="0"} 0.0
+rocprofiler_TA_BUSY_avr{card="0"} 0.0
+"""
+
 import ctypes
 import logging
 import os

--- a/omnistat/collector_rocprofiler.py
+++ b/omnistat/collector_rocprofiler.py
@@ -152,6 +152,6 @@ class rocprofiler(Collector):
             for j, name in enumerate(self.__names):
                 array = self.__values[i]
                 value = array[j].value.value
-                self.__metric.labels(card=i,counter=name).set(value)
+                self.__metric.labels(card=i, counter=name).set(value)
 
         return

--- a/omnistat/monitor.py
+++ b/omnistat/monitor.py
@@ -110,8 +110,9 @@ class Monitor:
             if config.has_option("omnistat.collectors.rms", "host_skip"):
                 self.runtimeConfig["rms_collector_host_skip"] = config["omnistat.collectors.rms"]["host_skip"]
 
-        if config.has_option("omniwatch.collectors.rocprofiler", "metrics"):
-            self.runtimeConfig["rocprofiler_metrics"] = config["omniwatch.collectors.rocprofiler"]["metrics"].split(",")
+        self.runtimeConfig["rocprofiler_metrics"] = []
+        if config.has_option("omnistat.collectors.rocprofiler", "metrics"):
+            self.runtimeConfig["rocprofiler_metrics"] = config["omnistat.collectors.rocprofiler"]["metrics"].split(",")
 
         # defined global prometheus metrics
         self.__globalMetrics = {}

--- a/omnistat/monitor.py
+++ b/omnistat/monitor.py
@@ -169,7 +169,9 @@ class Monitor:
         if self.runtimeConfig["collector_enable_rocprofiler"]:
             from omnistat.collector_rocprofiler import rocprofiler
 
-            self.__collectors.append(rocprofiler(self.runtimeConfig["collector_rocm_path"], self.runtimeConfig["rocprofiler_metrics"]))
+            self.__collectors.append(
+                rocprofiler(self.runtimeConfig["collector_rocm_path"], self.runtimeConfig["rocprofiler_metrics"])
+            )
 
         # Initialize all metrics
         for collector in self.__collectors:

--- a/omnistat/monitor.py
+++ b/omnistat/monitor.py
@@ -159,6 +159,11 @@ class Monitor:
 
             self.__collectors.append(ROCMEvents())
 
+        if self.runtimeConfig["collector_enable_rocprofiler"]:
+            from omnistat.collector_rocprofiler import rocprofiler
+
+            self.__collectors.append(rocprofiler(self.runtimeConfig["collector_rocm_path"], self.runtimeConfig["rocprofiler_metrics"]))
+
         # Initialize all metrics
         for collector in self.__collectors:
             collector.registerMetrics()

--- a/omnistat/monitor.py
+++ b/omnistat/monitor.py
@@ -85,6 +85,10 @@ class Monitor:
         self.runtimeConfig["collector_rocm_path"] = config["omnistat.collectors"].get("rocm_path", "/opt/rocm")
         self.runtimeConfig["collector_ras_ecc"] = config["omnistat.collectors"].getboolean("enable_ras_ecc", True)
 
+        self.runtimeConfig["collector_enable_rocprofiler"] = config["omnistat.collectors"].getboolean(
+            "enable_rocprofiler", False
+        )
+
         allowed_ips = config["omnistat.collectors"].get("allowed_ips", "127.0.0.1")
         # convert comma-separated string into list
         self.runtimeConfig["collector_allowed_ips"] = re.split(r",\s*", allowed_ips)
@@ -105,6 +109,9 @@ class Monitor:
             )
             if config.has_option("omnistat.collectors.rms", "host_skip"):
                 self.runtimeConfig["rms_collector_host_skip"] = config["omnistat.collectors.rms"]["host_skip"]
+
+        if config.has_option("omniwatch.collectors.rocprofiler", "metrics"):
+            self.runtimeConfig["rocprofiler_metrics"] = config["omniwatch.collectors.rocprofiler"]["metrics"].split(",")
 
         # defined global prometheus metrics
         self.__globalMetrics = {}


### PR DESCRIPTION
This is an alternative approach to #12. While I think the python module for rocprofiler device mode in #12 is something that can be potentially useful beyond this project, dealing with its building and installation is more complex and not as convenient as everything else we have in Omnistat.

The implementation in this PR is based on ctypes and is 1) simpler, 2) similar to our other collectors, 3) good enough in terms of performance.

I'll be using this approach for prototyping, and we can discuss future plans later.

