### PR TITLE
More reliable usermode executions

### DIFF
--- a/omnistat/omni_util.py
+++ b/omnistat/omni_util.py
@@ -173,10 +173,8 @@ class UserBasedMonitoring:
                 "srun",
                 "-N %s" % numNodes,
                 "--ntasks-per-node=1",
-                "--export=PYTHONPATH=%s" % ":".join(sys.path),
                 "%s" % sys.executable,
-                "-m",
-                "omnistat.rms_env",
+                "%s/omnistat-rms-env" % os.path.abspath(os.path.dirname(sys.argv[0])),
                 "%s" % self.runtimeConfig["omnistat.collectors.rms"].get("job_detection_file"),
             ]
             utils.runShellCommand(srun_cmd, timeout=35, exit_on_error=True)


### PR DESCRIPTION
This is an attempt to make sure usermode executions work more reliably in all environments. Changes:
- Use the `omnistat-rms-env` script instead of the `rms_env` module with srun.
- Propagate python path for exporters executed over SSH.

Propagating the python path also works fine for srun executions of `rms_env` (see differences in 066cfb5b4a344632a1469cceea7f654c3239a26d), but executing the `script` directly seems a little more simple.