### PR TITLE
Update numpy version

### DIFF
--- a/requirements-query.txt
+++ b/requirements-query.txt
@@ -1,4 +1,4 @@
-numpy>=1.25.2,<2.0.0
+numpy>=2.0.0
 matplotlib>=3.7.2
 prometheus-api-client>=0.5.4
 reportlab>=4.0.5


### PR DESCRIPTION
The query tool has been updated and we no longer need the conflict with numpy >= 2.
In fact, the new version actually requires trapezoid, which is new in 2.0.0.