### PR TITLE
Flush, compact, and merge Prometheus databases

### DIFF
--- a/tools/prometheus-flush.go
+++ b/tools/prometheus-flush.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/go-kit/log"
+	"github.com/prometheus/prometheus/tsdb"
+	"os"
+)
+
+func main() {
+	path := flag.String("path", "./data", "Path to Prometheus database")
+	flag.Parse()
+
+	sandbox := *path + "-sandbox"
+	output := *path + "-output"
+
+	if _, err := os.Stat(*path); err != nil {
+		fmt.Printf("Error: Unable to find database directory: %v\n", err)
+		return
+	}
+
+	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
+	db, err := tsdb.OpenDBReadOnly(*path, sandbox, logger)
+	if err != nil {
+		fmt.Printf("Error: Unable to open Prometheus database: %v\n", err)
+		return
+	}
+
+	err = db.FlushWAL(output)
+	if err != nil {
+		fmt.Println("Error: Failed to flush WAL: %v\n", err)
+		return
+	}
+}


### PR DESCRIPTION
This is an exploration to enable merging multiple Prometheus databases and resolve issues like #10, relying directly on Prometheus/TSDB. The main use case is a user generating traces for several related jobs in user mode, and then merging them to visualize them in the same dashboard.

This PR is still an early prototype. Current status:
- [x] Open and flush existing Prometheus database (create a block with data in WAL)
- [ ] Merge multiple databases (copy existing blocks from 2+ databases)
- [ ] Compact database (force compaction of a database to make sure performance doesn't degrade)
