### PR TITLE
Remove unused Flask metrics from exporter

### DIFF
--- a/omnistat/node_monitoring.py
+++ b/omnistat/node_monitoring.py
@@ -42,7 +42,6 @@ import sys
 import gunicorn.app.base
 
 from flask import Flask, request, abort, jsonify
-from flask_prometheus_metrics import register_metrics
 
 from omnistat import utils
 from omnistat.monitor import Monitor
@@ -95,7 +94,6 @@ def main():
     # preserve the state of the collectors.
     def post_fork(server, worker):
         monitor.initMetrics()
-        register_metrics(app, app_version="v0.1.0", app_config="production")
         app.route("/metrics")(monitor.updateAllMetrics)
         app.route("/shutdown")(shutdown)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 pyyaml
 importlib-metadata
 Flask>=2.3.2
-flask_prometheus_metrics>=1.0.0
 prometheus_client>=0.17.0
 gunicorn>=21.2.0
 packaging>=24.1


### PR DESCRIPTION
This is a small PR inspired by one of the changes in @omri-amd is suggesting in #98: commenting out the `register_metrics` line in `node_monitoring.py`.

`register_metrics` provides several metrics that we are not using. Since we are attempting to export the minimum amount of metrics we need, it makes sense to exclude these metrics in production environments.

This is the list of metrics currently exposed by `flask_prometheus_metrics` with `register_metrics`:
```
app_request_count_total
app_request_latency_seconds_bucket
app_version_info
app_request_count_created
app_request_latency_seconds_created
app_request_latency_seconds_sum
app_request_latency_seconds_count
app_request_count_total
```

Some of the values like the versioning can be misleading since we are using a hardcoded `0.1.0` instead of Omnistat's version.

The only reason to keep this around is to measure the performance of the Omnistat exporter. But if we only use these for Omnistat performance, I think it would make sense to keep them as optional.

This PR removes everything related `flask_prometheus_metrics`, partially because I wanted to test it and because I want to be careful about adding more configuration options.

Any thoughts about adding another option or entirely removing the Flask metrics?