### PR TITLE
provide metric naming parity between rocm-smi and amd-smi collector variants

### DIFF
--- a/omnistat/collector_smi.py
+++ b/omnistat/collector_smi.py
@@ -22,7 +22,7 @@
 # SOFTWARE.
 # -------------------------------------------------------------------------------
 
-"""ROCM-smi data collector
+"""ROCM-smi based data collector
 
 Implements a number of prometheus gauge metrics based on GPU data collected from
 rocm smi library.  The ROCm runtime must be pre-installed to use this data

--- a/omnistat/collector_smi_v2.py
+++ b/omnistat/collector_smi_v2.py
@@ -22,7 +22,7 @@
 # SOFTWARE.
 # -------------------------------------------------------------------------------
 
-"""amd-smi data collector
+"""amd-smi based data collector
 
 Implements a number of prometheus gauge metrics based on GPU data collected from
 amd-smi library.  The ROCm runtime must be pre-installed to use this data
@@ -95,7 +95,7 @@ def check_min_version(minVersion):
 class AMDSMI(Collector):
     def __init__(self):
         logging.debug("Initializing AMD SMI data collector")
-        self.__prefix = "amdsmi_"
+        self.__prefix = "rocm_"
         self.__schema = 1.0
         smi.amdsmi_init()
         logging.info("AMD SMI library API initialized")

--- a/omnistat/monitor.py
+++ b/omnistat/monitor.py
@@ -55,6 +55,15 @@ class Monitor:
         self.runtimeConfig["collector_enable_amd_smi"] = config["omnistat.collectors"].getboolean(
             "enable_amd_smi", False
         )
+
+        # verify only one SMI collector is enabled
+        if self.runtimeConfig["collector_enable_rocm_smi"] and self.runtimeConfig["collector_enable_amd_smi"]:
+            logging.error("")
+            logging.error("[ERROR]: Only one SMI GPU data collector may be configured at a time.")
+            logging.error("")
+            logging.error('Please choose either "enable_rocm_smi" or "enable_amd_smi" in runtime config')
+            sys.exit(1)
+
         self.runtimeConfig["collector_enable_amd_smi_process"] = config["omnistat.collectors"].getboolean(
             "enable_amd_smi_process", False
         )


### PR DESCRIPTION
Update amd-smi variant prefix so that it can be used as a drop-in replacement for rocm-smi  variant. The rocm-smi variant remains the production default but this prepares for future transition to amd-smi when necessary APIs are added.  The two variants now have full parity in their supplied metrics and naming schema. As a result, a runtime error check is added to ensure only one variant is enabled at a time.

Production metrics naming and example labels are highlighted below for a dual-GPU system:

```
rocm_num_gpus 2.0
rocm_version_info{card="1",driver_ver="6.8.5",schema="1.0",type="Instinct MI210",vbios="113-D67301V-073"} 1.0
rocm_version_info{card="0",driver_ver="6.8.5",schema="1.0",type="Instinct MI210",vbios="113-D67301V-073"} 1.0
rocm_temperature_celsius{card="1",location="edge"} 51.0
rocm_temperature_celsius{card="0",location="edge"} 49.0
rocm_temperature_hbm_celsius{card="1",location="hbm_0"} 46.0
rocm_temperature_hbm_celsius{card="0",location="hbm_0"} 45.0
rocm_average_socket_power_watts{card="1"} 42.0
rocm_average_socket_power_watts{card="0"} 42.0
rocm_sclk_clock_mhz{card="1"} 800.0
rocm_sclk_clock_mhz{card="0"} 800.0
rocm_mclk_clock_mhz{card="1"} 1600.0
rocm_mclk_clock_mhz{card="0"} 1600.0
rocm_vram_total_bytes{card="1"} 6.870269952e+010
rocm_vram_total_bytes{card="0"} 6.870269952e+010
rocm_vram_used_percentage{card="1"} 0.016
rocm_vram_used_percentage{card="0"} 0.016
rocm_vram_busy_percentage{card="1"} 0.0
rocm_vram_busy_percentage{card="0"} 0.0
rocm_utilization_percentage{card="1"} 0.0
rocm_utilization_percentage{card="0"} 0.0
```