### PR TITLE
Fix usermode options

### DIFF
--- a/docs/installation/user-mode.md
+++ b/docs/installation/user-mode.md
@@ -59,7 +59,7 @@ The following lines highlighted in yellow may need to be customized.
 ```eval_rst
 .. code-block:: ini
    :caption: Sample Omnistat configuration file
-   :emphasize-lines: 2,8,11
+   :emphasize-lines: 2,8,11,12,13
 
     [omnistat.collectors]
     port = 8001
@@ -71,6 +71,7 @@ The following lines highlighted in yellow may need to be customized.
     job_detection_file = /tmp/omni_rmsjobinfo_user
 
     [omnistat.usermode]
+    ssh_key = ~/.ssh/id_rsa
     prometheus_binary = /path/to/prometheus
     prometheus_datadir = data_prom
     prometheus_logfile = prom_server.log

--- a/docs/installation/user-mode.md
+++ b/docs/installation/user-mode.md
@@ -70,10 +70,10 @@ The following lines highlighted in yellow may need to be customized.
     job_detection_mode = file-based
     job_detection_file = /tmp/omni_rmsjobinfo_user
 
-    [omnistat.promserver]
-    binary = /path/to/prometheus
-    datadir = data_prom
-    logfile = prom_server.log
+    [omnistat.usermode]
+    prometheus_binary = /path/to/prometheus
+    prometheus_datadir = data_prom
+    prometheus_logfile = prom_server.log
   ```
 
 ## Running a SLURM Job

--- a/omnistat/config/omnistat.default
+++ b/omnistat/config/omnistat.default
@@ -36,7 +36,4 @@ system_name = My Snazzy System
 logfile = prom_server.log
 binary = /path-to-promeotheus-server-install/prometheus-2.45.1.linux-amd64/prometheus
 datadir = data_prom
-corebinding = 95
-
-
-
+# corebinding = 95

--- a/omnistat/config/omnistat.default
+++ b/omnistat/config/omnistat.default
@@ -5,12 +5,12 @@ enable_rocm_smi = True
 enable_amd_smi = False
 enable_rms = True
 
-# Path to local ROCM install to access SMI library
+## Path to local ROCM install to access SMI library
 rocm_path = /opt/rocm
 
-# List of IPs allowed to query the collector (comma separated). By
-# default, access will be restricted to the localhost (127.0.0.1).
-# Expand this value to include IP of local Prometheus server.
+## List of IPs allowed to query the collector (comma separated). By
+## default, access will be restricted to the localhost (127.0.0.1).
+## Expand this value to include IP of local Prometheus server.
 allowed_ips = 127.0.0.1
 
 [omnistat.collectors.rms]
@@ -39,7 +39,7 @@ prometheus_binary = /path-to-promeotheus-server-install/prometheus-2.45.1.linux-
 prometheus_datadir = data_prom
 prometheus_logfile = prom_server.log
 
-# Bind user-mode Omnistat monitor and Prometheus to a specific cores.
-# Requires numactl. When these options are not set, no binding is enforced.
+## Bind user-mode Omnistat monitor and Prometheus to a specific cores.
+## Requires numactl. When these options are not set, no binding is enforced.
 # exporter_corebinding = 0
 # prometheus_corebinding = 1

--- a/omnistat/config/omnistat.default
+++ b/omnistat/config/omnistat.default
@@ -20,9 +20,8 @@ enable_annotations = False
 job_detection_mode = file-based
 job_detection_file = /tmp/omni_rmsjobinfo
 
-[omnistat.report]
-
 [omnistat.query]
+
 prometheus_url = http://localhost:9090
 system_name = My Snazzy System
 

--- a/omnistat/config/omnistat.default
+++ b/omnistat/config/omnistat.default
@@ -10,9 +10,8 @@ rocm_path = /opt/rocm
 
 # List of IPs allowed to query the collector (comma separated). By
 # default, access will be restricted to the localhost (127.0.0.1).
-# Expand this value to include IP of local Prometheus server
+# Expand this value to include IP of local Prometheus server.
 allowed_ips = 127.0.0.1
-
 
 [omnistat.collectors.rms]
 
@@ -27,13 +26,18 @@ job_detection_file = /tmp/omni_rmsjobinfo
 prometheus_url = http://localhost:9090
 system_name = My Snazzy System
 
+
 #--
 # User-mode Settings
 #--
 
-# --user-spawned promserver
-[omnistat.promserver]
-logfile = prom_server.log
-binary = /path-to-promeotheus-server-install/prometheus-2.45.1.linux-amd64/prometheus
-datadir = data_prom
-# corebinding = 95
+[omnistat.usermode]
+
+prometheus_binary = /path-to-promeotheus-server-install/prometheus-2.45.1.linux-amd64/prometheus
+prometheus_datadir = data_prom
+prometheus_logfile = prom_server.log
+
+# Bind user-mode Omnistat monitor and Prometheus to a specific cores.
+# Requires numactl. When these options are not set, no binding is enforced.
+# exporter_corebinding = 0
+# prometheus_corebinding = 1

--- a/omnistat/config/omnistat.default
+++ b/omnistat/config/omnistat.default
@@ -33,6 +33,8 @@ system_name = My Snazzy System
 
 [omnistat.usermode]
 
+ssh_key = ~/.ssh/id_rsa
+
 prometheus_binary = /path-to-promeotheus-server-install/prometheus-2.45.1.linux-amd64/prometheus
 prometheus_datadir = data_prom
 prometheus_logfile = prom_server.log

--- a/omnistat/config/omnistat.ornl
+++ b/omnistat/config/omnistat.ornl
@@ -43,4 +43,6 @@ prometheus_binary = /autofs/nccs-svm1_sw/crusher/amdsw/omnistat/prometheus-2.45.
 # prometheus_datadir = /lustre/orion/%(SLURM_JOB_ACCOUNT)s/scratch/%(USER)s/omnistat/%(SLURM_JOB_ID)s
 prometheus_datadir = /lustre/orion/%(SLURM_JOB_ACCOUNT)s/world-shared/omnistat/%(SLURM_JOB_ID)s
 prometheus_logfile = prom_server.log
+
+exporter_corebinding = 0
 prometheus_corebinding = 95

--- a/omnistat/config/omnistat.ornl
+++ b/omnistat/config/omnistat.ornl
@@ -37,8 +37,6 @@ system_name = ORNL Frontier/Borg
 
 ssh_key = ~/.ssh/id_rsa
 
-template = prometheus.yml.template
-
 prometheus_binary = /autofs/nccs-svm1_sw/crusher/amdsw/omnistat/prometheus-2.45.1.linux-amd64/prometheus
 # prometheus_datadir = /lustre/orion/%(SLURM_JOB_ACCOUNT)s/scratch/%(USER)s/omnistat/%(SLURM_JOB_ID)s
 prometheus_datadir = /lustre/orion/%(SLURM_JOB_ACCOUNT)s/world-shared/omnistat/%(SLURM_JOB_ID)s

--- a/omnistat/config/omnistat.ornl
+++ b/omnistat/config/omnistat.ornl
@@ -14,7 +14,7 @@ rocm_path = /opt/rocm-6.2.0
 
 ## List of IPs allowed to query the collector (comma separated). By
 ## default, access will be restricted to the localhost (127.0.0.1).
-## Set this value to IP of companion Prometheus server.
+## Expand this value to include IP of local Prometheus server.
 allowed_ips = 127.0.0.1, 0.0.0.0
 
 [omnistat.collectors.rms]
@@ -22,9 +22,8 @@ allowed_ips = 127.0.0.1, 0.0.0.0
 host_skip = "login.*"
 enable_annotations = True
 
-[omnistat.report]
-
 [omnistat.query]
+
 prometheus_url = http://localhost:9090
 system_name = ORNL Frontier/Borg
 

--- a/omnistat/config/omnistat.ornl
+++ b/omnistat/config/omnistat.ornl
@@ -35,6 +35,8 @@ system_name = ORNL Frontier/Borg
 
 [omnistat.usermode]
 
+ssh_key = ~/.ssh/id_rsa
+
 template = prometheus.yml.template
 
 prometheus_binary = /autofs/nccs-svm1_sw/crusher/amdsw/omnistat/prometheus-2.45.1.linux-amd64/prometheus

--- a/omnistat/config/omnistat.ornl
+++ b/omnistat/config/omnistat.ornl
@@ -9,12 +9,12 @@ enable_rocm_smi = True
 enable_amd_smi = False
 enable_rms = True
 
-# Path to local ROCM install to access SMI library
+## Path to local ROCM install to access SMI library
 rocm_path = /opt/rocm-6.2.0
 
-# List of IPs allowed to query the collector (comma separated). By
-# default, access will be restricted to the localhost (127.0.0.1).
-# Set this value to IP of companion Prometheus server.
+## List of IPs allowed to query the collector (comma separated). By
+## default, access will be restricted to the localhost (127.0.0.1).
+## Set this value to IP of companion Prometheus server.
 allowed_ips = 127.0.0.1, 0.0.0.0
 
 [omnistat.collectors.rms]

--- a/omnistat/config/omnistat.ornl
+++ b/omnistat/config/omnistat.ornl
@@ -28,11 +28,17 @@ enable_annotations = True
 prometheus_url = http://localhost:9090
 system_name = ORNL Frontier/Borg
 
-# options for user-spawned promserver
-[omnistat.promserver]
+
+#--
+# User-mode Settings
+#--
+
+[omnistat.usermode]
+
 template = prometheus.yml.template
-logfile = prom_server.log
-corebinding = 95
-binary=/autofs/nccs-svm1_sw/crusher/amdsw/omnistat/prometheus-2.45.1.linux-amd64/prometheus
-#datadir = /lustre/orion/%(SLURM_JOB_ACCOUNT)s/scratch/%(USER)s/omnistat/%(SLURM_JOB_ID)s
-datadir = /lustre/orion/%(SLURM_JOB_ACCOUNT)s/world-shared/omnistat/%(SLURM_JOB_ID)s
+
+prometheus_binary = /autofs/nccs-svm1_sw/crusher/amdsw/omnistat/prometheus-2.45.1.linux-amd64/prometheus
+# prometheus_datadir = /lustre/orion/%(SLURM_JOB_ACCOUNT)s/scratch/%(USER)s/omnistat/%(SLURM_JOB_ID)s
+prometheus_datadir = /lustre/orion/%(SLURM_JOB_ACCOUNT)s/world-shared/omnistat/%(SLURM_JOB_ID)s
+prometheus_logfile = prom_server.log
+prometheus_corebinding = 95

--- a/omnistat/omni_util.py
+++ b/omnistat/omni_util.py
@@ -148,7 +148,7 @@ class UserBasedMonitoring:
             ]
 
             numactl = shutil.which("numactl")
-            if numactl and ps_corebinding != None:
+            if numactl and isinstance(ps_corebinding, int):
                 command = ["numactl", f"--physcpubind={ps_corebinding}"] + command
             else:
                 logging.info("Skipping Prometheus corebinding")
@@ -176,7 +176,7 @@ class UserBasedMonitoring:
         # Assume environment is the same across nodes; if numactl is present
         # here, we expect it to be present in all nodes.
         numactl = shutil.which("numactl")
-        if numactl and corebinding != None:
+        if numactl and isinstance(corebinding, int):
             cmd = f"numactl --physcpubind={corebinding} {cmd}"
         else:
             logging.info("Skipping exporter corebinding")

--- a/omnistat/omni_util.py
+++ b/omnistat/omni_util.py
@@ -88,25 +88,27 @@ class UserBasedMonitoring:
         else:
             scrape_timeout = scrape_interval
 
-        section = "omnistat.promserver"
-        ps_binary = self.runtimeConfig[section].get("binary")
-        ps_datadir = self.runtimeConfig[section].get("datadir", "data_prom", vars=os.environ)
+        section = "omnistat.usermode"
+        ps_binary = self.runtimeConfig[section].get("prometheus_binary")
+        ps_datadir = self.runtimeConfig[section].get("prometheus_datadir", "data_prom", vars=os.environ)
 
         # datadir can be overridden by separate env variable
         if "OMNISTAT_PROMSERVER_DATADIR" in os.environ:
             ps_datadir = os.getenv("OMNISTAT_PROMSERVER_DATADIR")
 
-        ps_logfile = self.runtimeConfig[section].get("logfile", "prom_server.log")
-        ps_corebinding = self.runtimeConfig[section].get("corebinding", None)
+        ps_logfile = self.runtimeConfig[section].get("prometheus_logfile", "prom_server.log")
+        ps_corebinding = self.runtimeConfig[section].get("prometheus_corebinding", None)
 
         # check if remote_write is desired
-        remoteWrite = self.runtimeConfig[section].getboolean("remote_write", False)
+        remoteWrite = self.runtimeConfig[section].getboolean("prometheus_remote_write", False)
         if remoteWrite:
             remoteWriteConfig = {}
-            remoteWriteConfig["url"] = self.runtimeConfig[section].get("remote_write_url", "unknown")
-            remoteWriteConfig["auth_user"] = self.runtimeConfig[section].get("remote_write_basic_auth_user", "user")
+            remoteWriteConfig["url"] = self.runtimeConfig[section].get("prometheus_remote_write_url", "unknown")
+            remoteWriteConfig["auth_user"] = self.runtimeConfig[section].get(
+                "prometheus_remote_write_basic_auth_user", "user"
+            )
             remoteWriteConfig["auth_cred"] = self.runtimeConfig[section].get(
-                "remote_write_basic_auth_cred", "credential"
+                "prometheus_remote_write_basic_auth_cred", "credential"
             )
             logging.debug("Remote write url:  %s" % remoteWriteConfig["url"])
             logging.debug("Remote write user: %s" % remoteWriteConfig["auth_user"])
@@ -169,7 +171,7 @@ class UserBasedMonitoring:
 
     def startExporters(self):
         port = self.runtimeConfig["omnistat.collectors"].get("port", "8001")
-        corebinding = self.runtimeConfig["omnistat.collectors"].get("corebinding", None)
+        corebinding = self.runtimeConfig["omnistat.usermode"].get("exporter_corebinding", None)
 
         cmd = f"nice -n 20 {sys.executable} -m omnistat.node_monitoring --configfile={self.configFile}"
 

--- a/omnistat/omni_util.py
+++ b/omnistat/omni_util.py
@@ -97,7 +97,7 @@ class UserBasedMonitoring:
             ps_datadir = os.getenv("OMNISTAT_PROMSERVER_DATADIR")
 
         ps_logfile = self.runtimeConfig[section].get("prometheus_logfile", "prom_server.log")
-        ps_corebinding = self.runtimeConfig[section].get("prometheus_corebinding", None)
+        ps_corebinding = self.runtimeConfig[section].getint("prometheus_corebinding", None)
 
         # check if remote_write is desired
         remoteWrite = self.runtimeConfig[section].getboolean("prometheus_remote_write", False)
@@ -172,7 +172,7 @@ class UserBasedMonitoring:
     def startExporters(self):
         port = self.runtimeConfig["omnistat.collectors"].get("port", "8001")
         ssh_key = self.runtimeConfig["omnistat.usermode"].get("ssh_key", "~/.ssh/id_rsa")
-        corebinding = self.runtimeConfig["omnistat.usermode"].get("exporter_corebinding", None)
+        corebinding = self.runtimeConfig["omnistat.usermode"].getint("exporter_corebinding", None)
 
         cmd = f"nice -n 20 {sys.executable} -m omnistat.node_monitoring --configfile={self.configFile}"
 

--- a/omnistat/omni_util.py
+++ b/omnistat/omni_util.py
@@ -171,6 +171,7 @@ class UserBasedMonitoring:
 
     def startExporters(self):
         port = self.runtimeConfig["omnistat.collectors"].get("port", "8001")
+        ssh_key = self.runtimeConfig["omnistat.usermode"].get("ssh_key", "~/.ssh/id_rsa")
         corebinding = self.runtimeConfig["omnistat.usermode"].get("exporter_corebinding", None)
 
         cmd = f"nice -n 20 {sys.executable} -m omnistat.node_monitoring --configfile={self.configFile}"
@@ -199,7 +200,7 @@ class UserBasedMonitoring:
 
             logging.info("Launching exporters in parallel using pdsh")
 
-            client = ParallelSSHClient(self.slurmHosts, allow_agent=False, timeout=300, pool_size=350)
+            client = ParallelSSHClient(self.slurmHosts, allow_agent=False, timeout=300, pool_size=350, pkey=ssh_key)
             try:
                 output = client.run_command(
                     f"sh -c 'cd {os.getcwd()} && PYTHONPATH={':'.join(sys.path)} {cmd}'", stop_on_errors=False

--- a/test/docker/slurm/omnistat-user.config
+++ b/test/docker/slurm/omnistat-user.config
@@ -18,8 +18,10 @@ job_detection_file = /tmp/omni_rmsjobinfo_usermode
 prometheus_url = http://localhost:9090
 system_name = SLURM in Docker Cluster
 
-[omnistat.promserver]
-logfile = prometheus-server.log
-binary = /usr/bin/prometheus
-datadir = prometheus-data
-corebinding = 0
+[omnistat.usermode]
+prometheus_logfile = prometheus-server.log
+prometheus_binary = /usr/bin/prometheus
+prometheus_datadir = prometheus-data
+
+exporter_corebinding = 0
+prometheus_corebinding = 0

--- a/test/docker/slurm/omnistat-user.config
+++ b/test/docker/slurm/omnistat-user.config
@@ -19,6 +19,8 @@ prometheus_url = http://localhost:9090
 system_name = SLURM in Docker Cluster
 
 [omnistat.usermode]
+ssh_key = ~/.ssh/id_rsa
+
 prometheus_logfile = prometheus-server.log
 prometheus_binary = /usr/bin/prometheus
 prometheus_datadir = prometheus-data


### PR DESCRIPTION
This PR addresses some issues with usermode options related to corebinding and SSH keys, and reorganizes usermode options under a single `[omnistat.usermode]` section.

Changes in corebinding:
- Remove default Prometheus binding on core 95.
- Make it possible to run without binding to any particular core when corebinding options are not set.
- Comment out corebinding by default.

New option for SSH keys:
- Introduce a new `ssh_key` option to customize the SSH key used to launching the exporters.