### PR TITLE
update name and query logic for memory temperature metric

### DIFF
--- a/grafana/json-models/rms-global.json
+++ b/grafana/json-models/rms-global.json
@@ -3921,7 +3921,7 @@
                 "uid": "${source}"
               },
               "editorMode": "code",
-              "expr": "avg by (instance,card) (rocm_temperature_hbm_celsius) ",
+              "expr": "avg by (instance,card) (rocm_temperature_memory_celsius) ",
               "instant": false,
               "legendFormat": "{{instance}}, {{card}}",
               "range": true,

--- a/grafana/json-models/standalone-global.json
+++ b/grafana/json-models/standalone-global.json
@@ -1641,7 +1641,7 @@
                 "uid": "${source}"
               },
               "editorMode": "code",
-              "expr": "avg by (instance,card) (rocm_temperature_hbm_celsius) ",
+              "expr": "avg by (instance,card) (rocm_temperature_memory_celsius) ",
               "instant": false,
               "legendFormat": "{{instance}}, {{card}}",
               "range": true,

--- a/omnistat/collector_smi.py
+++ b/omnistat/collector_smi.py
@@ -236,7 +236,7 @@ class ROCMSMI(Collector):
                 logging.info("--> Using primary temperature location at %s" % self.__temp_location_name)
                 break
 
-        # HBM memory location (not available on all parts)
+        # Cache valid memory temperature location
         self.__temp_memory_location_index = None
         for temp_type in rsmi_temperature_type_t:
             temp_location = ctypes.c_int32(temp_type.value)

--- a/omnistat/collector_smi.py
+++ b/omnistat/collector_smi.py
@@ -241,7 +241,9 @@ class ROCMSMI(Collector):
         for temp_type in rsmi_temperature_type_t:
             temp_location = ctypes.c_int32(temp_type.value)
             if "HBM" in temp_type.name or "VRAM" in temp_type.name:
-                ret = self.__libsmi.rsmi_dev_temp_metric_get(device, temp_location, temp_metric, ctypes.byref(temperature))
+                ret = self.__libsmi.rsmi_dev_temp_metric_get(
+                    device, temp_location, temp_metric, ctypes.byref(temperature)
+                )
                 if ret == 0 and temperature.value > 0:
                     self.__temp_memory_location_index = temp_location
                     self.__temp_memory_location_name = temp_type.name.removeprefix("RSMI_TEMP_TYPE_").lower()


### PR DESCRIPTION
This PR updates a metric name:

`rocm_temperature_hbm_celsius -> rocm_temperature_memory_celsius`

and enables support for a vram sensor location.

Examples samples with the update:

```
rocm_temperature_hbm_celsius{card="1",location="hbm_0"} 47.0
rocm_temperature_celsius{card="7",location="junction"} 39.0
```

