### PR TITLE
Improve error message when loading omnistat modules

### DIFF
--- a/omnistat-annotate
+++ b/omnistat-annotate
@@ -29,8 +29,9 @@ import sys
 
 try:
     from omnistat.annotate import main
-except:
-    print("Unable to load omnistat.annotate. Please verify installation.")
+except ImportError as err:
+    print(f"Unable to load Omnistat: {err}")
+    print("Please verify installation and dependencies.")
     sys.exit(1)
 
 if __name__ == "__main__":

--- a/omnistat-monitor
+++ b/omnistat-monitor
@@ -29,8 +29,9 @@ import sys
 
 try:
     from omnistat.node_monitoring import main
-except:
-    print("Unable to load omnistat.node_monitoring. Please verify installation.")
+except ImportError as err:
+    print(f"Unable to load Omnistat: {err}")
+    print("Please verify installation and dependencies.")
     sys.exit(1)
 
 if __name__ == "__main__":

--- a/omnistat-query
+++ b/omnistat-query
@@ -29,8 +29,9 @@ import sys
 
 try:
     from omnistat.query import main
-except:
-    print("Unable to load omnistat.query. Please verify installation.")
+except ImportError as err:
+    print(f"Unable to load Omnistat: {err}")
+    print("Please verify installation and dependencies.")
     sys.exit(1)
 
 if __name__ == "__main__":

--- a/omnistat-rms-env
+++ b/omnistat-rms-env
@@ -29,8 +29,9 @@ import sys
 
 try:
     from omnistat.rms_env import main
-except:
-    print("Unable to load omnistat.rms_env. Please verify installation.")
+except ImportError as err:
+    print(f"Unable to load Omnistat: {err}")
+    print("Please verify installation and dependencies.")
     sys.exit(1)
 
 if __name__ == "__main__":

--- a/omnistat-standalone
+++ b/omnistat-standalone
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# -------------------------------------------------------------------------------                                                                                                             # -------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # MIT License
 #
 # Copyright (c) 2023 - 2025 Advanced Micro Devices, Inc. All Rights Reserved.
@@ -32,8 +32,9 @@ if os.path.isdir("omnistat") and sys.path[0]:
 
 try:
     from omnistat.standalone import main
-except:
-    print("Unable to load omnistat.standalone. Please verify installation.")
+except ImportError as err:
+    print(f"Unable to load Omnistat: {err}")
+    print("Please verify installation and dependencies.")
     sys.exit(1)
 
 if __name__ == "__main__":

--- a/omnistat-standalone
+++ b/omnistat-standalone
@@ -27,9 +27,6 @@
 import os
 import sys
 
-if os.path.isdir("omnistat") and sys.path[0]:
-    sys.path.insert(0, "")
-
 try:
     from omnistat.standalone import main
 except ImportError as err:

--- a/omnistat-usermode
+++ b/omnistat-usermode
@@ -29,8 +29,9 @@ import sys
 
 try:
     from omnistat.omni_util import main
-except:
-    print("Unable to load omnistat.omni_util. Please verify installation.")
+except ImportError as err:
+    print(f"Unable to load Omnistat: {err}")
+    print("Please verify installation and dependencies.")
     sys.exit(1)
 
 if __name__ == "__main__":


### PR DESCRIPTION
The check before loading `omnistat` modules with the `try/except` block is no longer necessary, and generally leads to confusing error messages.

For example, if one of the dependencies is missing, the current approach will only show the error message saying the `omnistat` module couldn't be loaded and asking to verify installation. After removing this check, Python will just fail to import the missing module, making it easier to understand what's going on.