### PR TITLE
Support for exporting data using omnistat-query

### DIFF
--- a/docs/installation/user-mode.md
+++ b/docs/installation/user-mode.md
@@ -204,6 +204,7 @@ further processing.
 
    # Select GPU Utilization and GPU Memory Utilization for GPU ID 0 in all nodes
    df.loc[:, pandas.IndexSlice[["rocm_utilization_percentage", "rocm_vram_used_percentage"], :, ["0"]]]
+
   ```
 
 ```eval_rst
@@ -216,15 +217,10 @@ further processing.
    df = pandas.read_csv("data.csv", header=[0, 1, 2], index_col=0)
    df.index = pandas.to_datetime(df.index)
 
-   metric = "rocm_utilization_percentage"
-
    # Create a new dataframe with node averages
-   node_mean = pandas.DataFrame(index=df.index)
-   nodes = df[metric].columns.get_level_values("instance").unique()
-   for node in nodes:
-       node_mean[node] = df[metric][node].mean(axis=1)
+   node_mean_df = df["rocm_utilization_percentage"].T.groupby(level=['instance']).mean().T
 
-   node_mean.plot(linewidth=1)
+   node_mean_df.plot(linewidth=1)
    plt.title("Mean utilization per node")
    plt.xlabel("Time")
    plt.ylabel("GPU Utilization (%)")

--- a/docs/installation/user-mode.md
+++ b/docs/installation/user-mode.md
@@ -168,3 +168,40 @@ To explore results:
    ```shell-session
    [user@login]$ docker compose down
    ```
+
+## Exporting time series data
+
+To explore and process raw Omnistat data without relying on the Docker
+environment or a Prometheus/VictoriaMetrics server, the `omnistat-query` tool
+has an option to export all time series data to a CSV file.
+
+```eval_rst
+.. code-block:: bash
+   :caption: Using the export option in `omnistat-query`
+
+   ${OMNISTAT_DIR}/omnistat-query --job ${jobid} --interval 1 --export data.csv
+  ```
+
+Exported data can be easily loaded as a data frame using tools like Pandas for
+further processing.
+
+```eval_rst
+.. code-block:: python
+   :caption: Python script to read exported time series as a Pandas data frame
+
+   import pandas
+
+   df = pandas.read_csv("data.csv", header=[0, 1, 2], index_col=0)
+
+   # Select a single metric
+   df["rocm_utilization_percentage"]
+
+   # Select a single metric and node
+   df["rocm_utilization_percentage"]["node01"]
+
+   # Select a single metric, node, and GPU
+   df["rocm_utilization_percentage"]["node01"]["0"]
+
+   # Select GPU Utilization and GPU Memory Utilization for GPU ID 0 in all nodes
+   df.loc[:, pandas.IndexSlice[["rocm_utilization_percentage", "rocm_vram_used_percentage"], :, ["0"]]]
+  ```

--- a/docs/installation/user-mode.md
+++ b/docs/installation/user-mode.md
@@ -205,3 +205,28 @@ further processing.
    # Select GPU Utilization and GPU Memory Utilization for GPU ID 0 in all nodes
    df.loc[:, pandas.IndexSlice[["rocm_utilization_percentage", "rocm_vram_used_percentage"], :, ["0"]]]
   ```
+
+```eval_rst
+.. code-block:: python
+   :caption: Python script to plot average GPU Utilization per node
+
+   import pandas
+   import matplotlib.pyplot as plt
+
+   df = pandas.read_csv("data.csv", header=[0, 1, 2], index_col=0)
+   df.index = pandas.to_datetime(df.index)
+
+   metric = "rocm_utilization_percentage"
+
+   # Create a new dataframe with node averages
+   node_mean = pandas.DataFrame(index=df.index)
+   nodes = df[metric].columns.get_level_values("instance").unique()
+   for node in nodes:
+       node_mean[node] = df[metric][node].mean(axis=1)
+
+   node_mean.plot(linewidth=1)
+   plt.title("Mean utilization per node")
+   plt.xlabel("Time")
+   plt.ylabel("GPU Utilization (%)")
+   plt.show()
+  ```

--- a/omnistat/query.py
+++ b/omnistat/query.py
@@ -850,11 +850,10 @@ class queryMetrics:
             output_file (string): path to output CSV file
         """
 
-        df = pandas.DataFrame()
-
         index = ["timestamp", "instance", "card"]
         pivot_labels = ["instance", "card"]
 
+        metric_dfs = []
         for metric in self.metrics:
             metric_name = metric["metric"]
             metric_data = self.prometheus.custom_query_range(
@@ -891,8 +890,9 @@ class queryMetrics:
             metric_df.columns = metric_df.columns.set_names("metric", level=0)
             metric_df = metric_df.sort_index(axis=1)
 
-            df = pandas.concat([df, metric_df], axis=1)
+            metric_dfs.append(metric_df)
 
+        df = pandas.concat(metric_dfs, axis=1)
         df.to_csv(output_file)
 
 

--- a/omnistat/query.py
+++ b/omnistat/query.py
@@ -858,7 +858,8 @@ class queryMetrics:
         for metric in self.metrics:
             metric_name = metric["metric"]
             metric_data = self.prometheus.custom_query_range(
-                '(%s * on (instance) group_left() rmsjob_info{jobid="%s",%s})' % (metric_name, self.jobID, self.jobstepQuery),
+                '(%s * on (instance) group_left() rmsjob_info{jobid="%s",%s})'
+                % (metric_name, self.jobID, self.jobstepQuery),
                 self.start_time,
                 self.end_time,
                 step=self.interval,
@@ -893,6 +894,7 @@ class queryMetrics:
             df = pandas.concat([df, metric_df], axis=1)
 
         df.to_csv(output_file)
+
 
 def main():
 
@@ -931,6 +933,7 @@ def main():
 
     if args.export:
         query.export(args.export)
+
 
 if __name__ == "__main__":
     main()

--- a/omnistat/query.py
+++ b/omnistat/query.py
@@ -844,6 +844,12 @@ class queryMetrics:
         return
 
     def export(self, output_file):
+        """Export time series for all metrics/nodes/GPUs as a CSV file
+
+        Args:
+            output_file (string): path to output CSV file
+        """
+
         df = pandas.DataFrame()
 
         index = ["timestamp", "instance", "card"]

--- a/requirements-query.txt
+++ b/requirements-query.txt
@@ -1,5 +1,6 @@
-numpy>=2.0.0
+bottleneck>=1.3.6
 matplotlib>=3.7.2
+numpy>=2.0.0
+pandas>=2.2.0
 prometheus-api-client>=0.5.4
 reportlab>=4.0.5
-bottleneck>=1.3.6


### PR DESCRIPTION
This PR introduces a new `--export` flag in `omnistat-query` to export time series as CSV for easier processing with external tools without relying on Prometheus/VictoriaMetrics and Grafana.

Optional tasks, to be decided if included in this PR or later:
- [ ] 1. Refactor PromQL queries for easier reuse. In particular, the new export function requires a custom query to get all the raw data. `query_time_series_data()` cannot be reused as is because it expects a metric with a specific card ID, such as `rocm_utilization_percentage{card="0"}`, or is reduced with some other function.
- [ ] 2. Add another `--exportformat` flag to allow storing data in [other formats supported by Pandas](https://pandas.pydata.org/docs/user_guide/io.html). Relatively easy to support, but CSV is simple and works for testing the export feature. Other formats can be added as needed on demand.
- [ ] 3. Improve export documentation. Do we need more examples? Plotting?
- [ ] 4. Handle additional labels. Certain metrics have labels other than `instance` and `card`. For example `rocm_temperature_celsius` has `location`. At the moment these are ignored because we don't have more than one additional label at a time, and supporting more labels makes the data frame significantly more complex to work with. One option to address this sort of scenario while keeping the data simple is adding a suffix to the metric to include the additional label. For example: `rocm_temperature_celsius [edge]` or `rocm_temperature_celsius (location: edge)`.