### PR TITLE
Make responses text/plain instead of text/html

### DIFF
--- a/omnistat/node_monitoring.py
+++ b/omnistat/node_monitoring.py
@@ -93,7 +93,7 @@ def main():
     # preserve the state of the collectors.
     def post_fork(server, worker):
         monitor.initMetrics()
-        app.route("/metrics")(monitor.updateAllMetrics)
+        app.route("/metrics")(lambda: (monitor.updateAllMetrics(), {"Content-Type": "text/plain; charset=utf-8"}))
         app.route("/shutdown")(shutdown)
 
     listenPort = config["omnistat.collectors"].get("port", 8001)


### PR DESCRIPTION
This PR makes sure the Omnistat endpoint generates responses with `text/plain` as content type in the HTTP headers, which is the correct value for a Prometheus endpoint.

By default, Flask responds with a `text/html` content type, which seems to break third-party tools that expect `text/plain`.