### PR TITLE
victoriametric tweaks to flush cache after backfilling data via push api

### DIFF
--- a/omnistat/omni_util.py
+++ b/omnistat/omni_util.py
@@ -138,6 +138,7 @@ class UserBasedMonitoring:
             "--storageDataPath=%s" % vm_datadir,
             "-memory.allowedPercent=10",
             "-retentionPeriod=10y",
+            "-search.disableCache",
             "-httpListenAddr=:9090",
         ]
         envAddition = {}

--- a/omnistat/omni_util.py
+++ b/omnistat/omni_util.py
@@ -292,7 +292,7 @@ class UserBasedMonitoring:
                 ]
                 utils.runShellCommand(flux_cmd, timeout=35, exit_on_error=True)
 
-            logging.info("Launching exporters in parallel using pdsh")
+            logging.info("Launching exporters in parallel via ssh")
 
             client = ParallelSSHClient(self.__hosts, allow_agent=False, timeout=300, pool_size=350, pkey=ssh_key)
             try:
@@ -300,7 +300,7 @@ class UserBasedMonitoring:
                     f"sh -c 'cd {os.getcwd()} && PYTHONPATH={':'.join(sys.path)} {cmd}'", stop_on_errors=False
                 )
             except:
-                logging.info("Exception thrown launching parallell ssh client")
+                logging.info("Exception thrown launching parallel ssh client")
 
             # verify exporter available on all nodes...
             if len(self.__hosts) <= 8:

--- a/omnistat/query.py
+++ b/omnistat/query.py
@@ -138,6 +138,7 @@ class queryMetrics:
         # NOOP if job is very short running
         runtime = (self.end_time - self.start_time).total_seconds()
         if runtime < 61:
+            logging.info("--> Short duration job detected...(%.1f secs) - unsupported query." % runtime)
             sys.exit()
 
         # cache hosts assigned to job

--- a/omnistat/standalone.py
+++ b/omnistat/standalone.py
@@ -82,11 +82,11 @@ def push_to_victoria_metrics(metrics_data_list, victoria_url):
         logging.info("Metrics pushed successfully!")
 
     # notify on backfill event
-    endpoints = ["/internal/resetRollupResultCache","/internal/force_flush"]
+    endpoints = ["/internal/resetRollupResultCache", "/internal/force_flush"]
     for endpoint in endpoints:
         try:
             response = requests.get(victoria_url + endpoint)
-            logging.debug("--> Response from victoria endpoint %s = %s" % (endpoint,response.status_code))
+            logging.debug("--> Response from victoria endpoint %s = %s" % (endpoint, response.status_code))
         except Exception as e:
             logging.error("")
             logging.error("[FAILED]: Unable to GET Victoria endpoint -> %s" % endpoint)

--- a/omnistat/standalone.py
+++ b/omnistat/standalone.py
@@ -134,11 +134,8 @@ class Standalone:
             time.sleep(delay)
 
         if failed:
-            logging.error("")
-            logging.error("[ERROR]: Unable to access VictoriaMetrics server endpoint (%s)" % self.__victoriaURL)
-            logging.error("[ERROR]: Please verify server is running and accessible from this host.")
-            logging.error("")
-            sys.exit(1)
+            logging.warning("[WARN]: Unable to access VictoriaMetrics server endpoint (%s)" % self.__victoriaURL)
+            logging.warning("[WARN]: Please verify server is running and accessible from this host.")
 
         logging.info("Cached data will be pushed every %i minute(s)" % self.__pushFrequencyMins)
 


### PR DESCRIPTION
This PR modifies the push process slightly in user-mode when using VictoriaMetrics data store to include additional flush operations.  The changes address occasional issues observed for test jobs in a large supercomputing environment where collected telemetry was not immediately visible via a Prometheus query at the end of a very short job (e.g. 120 secs).
