### PR TITLE
introduce verifyNumaCommand() support function 

### DIFF
--- a/omnistat/omni_util.py
+++ b/omnistat/omni_util.py
@@ -392,7 +392,7 @@ class UserBasedMonitoring:
             utils.runShellCommand(cmd, timeout=timeout)
         return
 
-    def verifyNumaCommand(self, coreid):        
+    def verifyNumaCommand(self, coreid):
         """Verify numactl is available and works with supplied core id when provided
 
         Args:


### PR DESCRIPTION
Introduces a verifyNumaCommand() support function that is used to verify supplied cpu core at runtime is available for use with `numactl` to satisfy #153.