### PR TITLE
include metrics tracking error counts for a GPU block

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ basis). Relevant target metrics include:
 * GPU memory clock frequency
 * GPU block error counts
 * GPU throttling events
+* Inventory information
+ ** ROCm driver version
+ ** GPU type
+ ** GPU vBIOS version
 
 The data can be scraped for detailed visualization and analysis via a
 combination of [Prometheus](https://prometheus.io/) /

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ basis). Relevant target metrics include:
 * High-bandwidth memory (HBM) usage
 * GPU power
 * GPU temperature
-* GPU clock frequency (Mhz)
-* GPU memory clock frequency (Mhz)
+* GPU clock frequency
+* GPU memory clock frequency
+* GPU block error counts
 * GPU throttling events
 
 The data can be scraped for detailed visualization and analysis via a

--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -29,11 +29,15 @@ collected.
   - [Job Dashboard](https://github.com/AMDResearch/omnistat/blob/main/grafana/json-models/rms-job.json):
     provides detailed time-series data, load distribution, and other metrics for
     a single job.
+
 - *Standalone* dashboards are meant to work without a resource manager.
   - [Global Dashboard](https://github.com/AMDResearch/omnistat/blob/main/grafana/json-models/standalone-global.json):
     provides an overview of the system and cluster-level telemetry.
   - [Node Dashboard](https://github.com/AMDResearch/omnistat/blob/main/grafana/json-models/standalone-node.json):
     detailed metrics for a single node in the cluster.
+
+- *RAS* dashboards are meant to summarize RAS events collected across the cluster.
+  - [RAS Summary](https://github.com/AMDResearch/omnistat/blob/main/grafana/json-models/ras-summary.json): provides an overview of RAS GPU counters across all hosts (with or without resource manager integration).
 
 
 ## Grafana server

--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -37,7 +37,7 @@ collected.
     detailed metrics for a single node in the cluster.
 
 - *RAS* dashboards are meant to summarize RAS events collected across the cluster.
-  - [RAS Summary](https://github.com/AMDResearch/omnistat/blob/main/grafana/json-models/ras-summary.json): provides an overview of RAS GPU counters across all hosts (with or without resource manager integration).
+  - [RAS Summary](https://github.com/AMDResearch/omnistat/blob/main/grafana/json-models/ras-summary.json): provides an overview of RAS GPU counters across all hosts (with or without resource manager integration). Can be used in combination with RMS-based Node Dashboard above to isolate RAS events to specific hosts and user jobs.
 
 
 ## Grafana server

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -18,8 +18,10 @@ Omnistat provides a set of utilities to aid cluster administrators or individual
 * High-bandwidth memory (HBM) usage
 * GPU power
 * GPU temperature(s)
-* GPU clock frequency (Mhz)
-* GPU memory clock frequency (Mhz)
+* GPU clock frequency
+* GPU memory clock frequency
+* RAS information:
+  * Error counts per GPU block
 * Inventory information:
   * ROCm driver version
   * GPU type

--- a/grafana/json-models/ras-summary.json
+++ b/grafana/json-models/ras-summary.json
@@ -1,0 +1,959 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_GRAFANACLOUD-KOOMIE-PROM",
+      "label": "grafanacloud-koomie-prom",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.6.0-84491.patch1-84812"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+      },
+      "description": "Aggregating all RAS events in each node. Only showing blocks/nodes with errors. A panel with \"No data\" indicates no errors have been reported during the selected time window.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Events/m",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Name",
+          "sortDesc": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0-84491.patch1-84812",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (instance) (delta(rocm_ras_umc_correctable_count[1m])) > 0",
+          "instant": false,
+          "legendFormat": "UMC: {{instance}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (instance) (delta(rocm_ras_sdma_correctable_count[1m])) > 0",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "SDMA: {{instance}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (instance) (delta(rocm_ras_gfx_correctable_count[1m])) >0",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "GFX: {{instance}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (instance) (delta(rocm_ras_mmhub_correctable_count[1m])) >0",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "MMHUB: {{instance}}",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (instance) (delta(rocm_ras_pcie_bif_correctable_count[1m])) >0",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "PCIE BIF: {{instance}}",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (instance) (delta(rocm_ras_hdp_correctable_count[1m])) >0",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "HDP: {{instance}}",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (instance) (delta(rocm_ras_xgmi_wafl_correctable_count[1m])) >0",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "XGMI WAFL: {{instance}}",
+          "range": true,
+          "refId": "G"
+        }
+      ],
+      "title": "Summary of Hosts with Non-zero Rate of Correctable Errors (errors/min)",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "(.*): (.*)",
+            "renamePattern": "$2 ($1)"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+      },
+      "description": "Aggregating all RAS events in each node. Only showing blocks/nodes with errors.  A panel with \"No data\" indicates no errors have been reported during the selected time window.\n",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Events/m",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Name",
+          "sortDesc": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0-84491.patch1-84812",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (instance) (delta(rocm_ras_umc_uncorrectable_count[1m])) >0",
+          "instant": false,
+          "legendFormat": "UMC: {{instance}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (instance) (delta(rocm_ras_sdma_uncorrectable_count[1m])) >0",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "SDMA: {{instance}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (instance) (delta(rocm_ras_gfx_uncorrectable_count[1m])) >0",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "GFX: {{instance}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (instance) (delta(rocm_ras_mmhub_uncorrectable_count[1m])) >0",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "MMHUB: {{instance}}",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (instance) (delta(rocm_ras_pcie_bif_uncorrectable_count[1m])) >0",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "PCIE BIF: {{instance}}",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (instance) (delta(rocm_ras_hdp_uncorrectable_count[1m])) >0",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "HDP: {{instance}}",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (instance) (delta(rocm_ras_xgmi_wafl_uncorrectable_count[1m])) >0",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "XGMI WAFL: {{instance}}",
+          "range": true,
+          "refId": "G"
+        }
+      ],
+      "title": "Summary of Hosts with Non-zero Rate of Uncorrectable Errors (errors/min)",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "(.*): (.*)",
+            "renamePattern": "$2 ($1)"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0-84491.patch1-84812",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (instance) ({__name__=~\"rocm_ras_.+_correctable_count\"})",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "History of Correctable Errors per Node",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0-84491.patch1-84812",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (instance) ({__name__=~\"rocm_ras_.+_uncorrectable_count\"})",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Uncorrectable Errors Logged per Host",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+      },
+      "description": "A panel with \"No data\" indicates no errors have been reported during the selected time window.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "links": [
+            {
+              "title": "Node dashboard",
+              "url": "d/fdxiufe2bkyrkd-source/node-source?orgId=1&var-instance=${__value.raw}&${__url_time_range}"
+            }
+          ],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 3,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "11.6.0-84491.patch1-84812",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (instance) ({__name__=~\"rocm_ras_.+_correctable_count\"})",
+          "format": "table",
+          "hide": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Hosts with Non-zero Correctable Errors",
+      "transformations": [
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "Value": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "instance": {
+                "aggregations": [],
+                "operation": "groupby"
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value (max)": "Max Count",
+              "instance": "Node"
+            }
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "greater",
+                  "options": {
+                    "value": 0
+                  }
+                },
+                "fieldName": "Max Count"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Max Count"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+      },
+      "description": "A panel with \"No data\" indicates no errors have been reported during the selected time window.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "links": [
+            {
+              "title": "Node dashboard",
+              "url": "d/fdxiufe2bkyrkd-source/node-source?orgId=1&var-instance=${__value.raw}&${__url_time_range}"
+            }
+          ],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 5,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "11.6.0-84491.patch1-84812",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (instance) ({__name__=~\"rocm_ras_.+_uncorrectable_count\"})",
+          "format": "table",
+          "hide": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Hosts with Uncorrectable Errors",
+      "transformations": [
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "Value": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "instance": {
+                "aggregations": [],
+                "operation": "groupby"
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value (max)": "Max Count",
+              "instance": "Node"
+            }
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "greater",
+                  "options": {
+                    "value": 0
+                  }
+                },
+                "fieldName": "Max Count"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Max Count"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 2,
+        "includeAll": false,
+        "name": "source",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "Prometheus-m2m-oci",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "ras-summary",
+  "uid": "edqnz7pce7togc-ras-summary",
+  "version": 4,
+  "weekStart": ""
+}

--- a/grafana/json-models/ras-summary.json
+++ b/grafana/json-models/ras-summary.json
@@ -1,41 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_GRAFANACLOUD-KOOMIE-PROM",
-      "label": "grafanacloud-koomie-prom",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "11.6.0-84491.patch1-84812"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -67,7 +30,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+        "uid": "${source}"
       },
       "description": "Aggregating all RAS events in each node. Only showing blocks/nodes with errors. A panel with \"No data\" indicates no errors have been reported during the selected time window.",
       "fieldConfig": {
@@ -153,7 +116,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+            "uid": "${source}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -166,7 +129,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+            "uid": "${source}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -180,7 +143,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+            "uid": "${source}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -194,7 +157,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+            "uid": "${source}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -208,7 +171,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+            "uid": "${source}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -222,7 +185,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+            "uid": "${source}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -236,7 +199,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+            "uid": "${source}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -263,7 +226,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+        "uid": "${source}"
       },
       "description": "Aggregating all RAS events in each node. Only showing blocks/nodes with errors.  A panel with \"No data\" indicates no errors have been reported during the selected time window.\n",
       "fieldConfig": {
@@ -349,7 +312,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+            "uid": "${source}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -362,7 +325,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+            "uid": "${source}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -376,7 +339,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+            "uid": "${source}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -390,7 +353,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+            "uid": "${source}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -404,7 +367,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+            "uid": "${source}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -418,7 +381,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+            "uid": "${source}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -432,7 +395,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+            "uid": "${source}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -459,7 +422,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+        "uid": "${source}"
       },
       "fieldConfig": {
         "defaults": {
@@ -540,7 +503,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+            "uid": "${source}"
           },
           "editorMode": "code",
           "expr": "sum by (instance) ({__name__=~\"rocm_ras_.+_correctable_count\"})",
@@ -555,7 +518,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+        "uid": "${source}"
       },
       "description": "",
       "fieldConfig": {
@@ -637,7 +600,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+            "uid": "${source}"
           },
           "editorMode": "code",
           "expr": "sum by (instance) ({__name__=~\"rocm_ras_.+_uncorrectable_count\"})",
@@ -652,7 +615,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+        "uid": "${source}"
       },
       "description": "A panel with \"No data\" indicates no errors have been reported during the selected time window.",
       "fieldConfig": {
@@ -714,7 +677,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+            "uid": "${source}"
           },
           "editorMode": "code",
           "expr": "sum by (instance) ({__name__=~\"rocm_ras_.+_correctable_count\"})",
@@ -791,7 +754,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+        "uid": "${source}"
       },
       "description": "A panel with \"No data\" indicates no errors have been reported during the selected time window.",
       "fieldConfig": {
@@ -853,7 +816,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-KOOMIE-PROM}"
+            "uid": "${source}"
           },
           "editorMode": "code",
           "expr": "sum by (instance) ({__name__=~\"rocm_ras_.+_uncorrectable_count\"})",
@@ -934,14 +897,13 @@
   "templating": {
     "list": [
       {
-        "current": {},
         "hide": 2,
         "includeAll": false,
         "name": "source",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "Prometheus-m2m-oci",
+        "regex": "",
         "type": "datasource"
       }
     ]

--- a/grafana/json-models/rms-node.json
+++ b/grafana/json-models/rms-node.json
@@ -98,7 +98,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.3.0-76576",
+      "pluginVersion": "8.5.3",
       "targets": [
         {
           "datasource": {
@@ -154,9 +154,7 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "uniqueValues"
-          ],
+          "calcs": [],
           "fields": "/^type$/",
           "values": false
         },
@@ -165,7 +163,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.3.0-76576",
+      "pluginVersion": "8.5.3",
       "targets": [
         {
           "datasource": {
@@ -243,7 +241,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.3.0-76576",
+      "pluginVersion": "8.5.3",
       "targets": [
         {
           "datasource": {
@@ -319,7 +317,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.3.0-76576",
+      "pluginVersion": "8.5.3",
       "targets": [
         {
           "datasource": {
@@ -388,7 +386,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.3.0-76576",
+      "pluginVersion": "8.5.3",
       "targets": [
         {
           "datasource": {
@@ -465,7 +463,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.3.0-76576",
+      "pluginVersion": "8.5.3",
       "targets": [
         {
           "datasource": {
@@ -541,7 +539,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.3.0-76576",
+      "pluginVersion": "8.5.3",
       "targets": [
         {
           "datasource": {
@@ -572,16 +570,19 @@
           },
           "custom": {
             "fillOpacity": 70,
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
             "lineWidth": 1,
             "spanNulls": false
           },
           "mappings": [
+            {
+              "options": {
+                "1": {
+                  "index": 1,
+                  "text": "Allocated"
+                }
+              },
+              "type": "value"
+            },
             {
               "options": {
                 "match": "nan",
@@ -600,10 +601,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }
@@ -611,7 +608,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
+        "h": 6,
         "w": 24,
         "x": 0,
         "y": 9
@@ -621,29 +618,30 @@
       "options": {
         "alignValue": "left",
         "legend": {
-          "displayMode": "list",
+          "displayMode": "hidden",
           "placement": "bottom",
           "showLegend": false
         },
         "mergeValues": true,
         "rowHeight": 0.9,
-        "showValue": "auto",
+        "showValue": "never",
         "tooltip": {
-          "mode": "multi",
+          "hideZeros": false,
+          "mode": "none",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.3.0-76576",
+      "pluginVersion": "11.6.0-83314",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${source}"
+            "uid": "rjpu9PXSz"
           },
           "editorMode": "code",
-          "expr": "count by (job,instance,jobid) (rmsjob_info{instance=\"$instance\"})",
+          "expr": "count by (job,instance,jobid) (rmsjob_info{instance=\"$instance\",jobid!=\"\"})",
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "{{jobid}}",
           "range": true,
           "refId": "A"
         }
@@ -651,16 +649,19 @@
       "title": "Allocation Summary",
       "transformations": [
         {
+          "disabled": true,
           "id": "seriesToRows",
           "options": {}
         },
         {
+          "disabled": true,
           "id": "extractFields",
           "options": {
             "source": "Metric"
           }
         },
         {
+          "disabled": true,
           "id": "organize",
           "options": {
             "excludeByName": {
@@ -678,13 +679,22 @@
           }
         },
         {
+          "disabled": true,
           "id": "calculateField",
           "options": {
             "alias": "Job",
             "binary": {
-              "left": "jobid",
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "jobid"
+                }
+              },
               "operator": "*",
-              "right": "1"
+              "reducer": "sum",
+              "right": {
+                "fixed": "1"
+              }
             },
             "cumulative": {
               "field": "jobid",
@@ -704,303 +714,208 @@
       "type": "state-timeline"
     },
     {
-      "collapsed": false,
+      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 14
-      },
-      "id": 9,
-      "panels": [],
-      "title": "GPU - Utilization",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${source}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "scaleDistribution": {
-              "type": "linear"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 24,
-        "x": 0,
         "y": 15
       },
-      "id": 6,
-      "options": {
-        "calculate": false,
-        "cellGap": 1,
-        "cellValues": {
-          "decimals": 0,
-          "unit": "percent"
-        },
-        "color": {
-          "exponent": 0.5,
-          "fill": "dark-orange",
-          "max": 100,
-          "min": 0,
-          "mode": "scheme",
-          "reverse": false,
-          "scale": "exponential",
-          "scheme": "RdYlGn",
-          "steps": 64
-        },
-        "exemplars": {
-          "color": "rgba(255,0,255,0.7)"
-        },
-        "filterValues": {
-          "le": 1e-09
-        },
-        "legend": {
-          "show": true
-        },
-        "rowsFrame": {
-          "layout": "auto"
-        },
-        "tooltip": {
-          "maxHeight": 600,
-          "mode": "single",
-          "showColorScale": false,
-          "yHistogram": false
-        },
-        "yAxis": {
-          "axisPlacement": "left",
-          "reverse": false
-        }
-      },
-      "pluginVersion": "11.3.0-76576",
-      "targets": [
+      "id": 9,
+      "panels": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${source}"
           },
-          "editorMode": "code",
-          "expr": "rocm_utilization_percentage{instance=\"$instance\"}",
-          "instant": false,
-          "legendFormat": "GPU ID {{card}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "GPU Utilization Heatmap",
-      "type": "heatmap"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${source}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMax": 100,
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
           },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisSoftMax": 100,
-            "axisSoftMin": 0,
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 16
+          },
+          "id": 29,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "sortBy": "Name",
+              "sortDesc": false
             },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
+            "tooltip": {
+              "maxHeight": 600,
+              "mode": "single",
+              "sort": "none"
             }
           },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": null
-              }
-            ]
-          },
-          "unit": "percent"
+          "pluginVersion": "11.3.0-76576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${source}"
+              },
+              "editorMode": "code",
+              "expr": "(rocm_utilization_percentage{instance=\"$instance\"})",
+              "instant": false,
+              "legendFormat": "GPU ID {{card}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GPU Utlization (%)",
+          "type": "timeseries"
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 24,
-        "x": 0,
-        "y": 24
-      },
-      "id": 29,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true,
-          "sortBy": "Name",
-          "sortDesc": false
-        },
-        "tooltip": {
-          "maxHeight": 600,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.3.0-76576",
-      "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${source}"
           },
-          "editorMode": "code",
-          "expr": "(rocm_utilization_percentage{instance=\"$instance\"})",
-          "instant": false,
-          "legendFormat": "GPU ID {{card}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "GPU Utlization (%)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${source}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMax": 100,
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
           },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisSoftMax": 100,
-            "axisSoftMin": 0,
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 25
+          },
+          "id": 107,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "sortBy": "Name",
+              "sortDesc": false
             },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
+            "tooltip": {
+              "maxHeight": 600,
+              "mode": "single",
+              "sort": "none"
             }
           },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": null
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 24,
-        "x": 0,
-        "y": 33
-      },
-      "id": 107,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true,
-          "sortBy": "Name",
-          "sortDesc": false
-        },
-        "tooltip": {
-          "maxHeight": 600,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.3.0-76576",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${source}"
-          },
-          "editorMode": "code",
-          "expr": "rocm_vram_used_percentage{instance=\"$instance\"}",
-          "instant": false,
-          "legendFormat": "GPU ID {{card}}",
-          "range": true,
-          "refId": "A"
+          "pluginVersion": "11.3.0-76576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${source}"
+              },
+              "editorMode": "code",
+              "expr": "rocm_vram_used_percentage{instance=\"$instance\"}",
+              "instant": false,
+              "legendFormat": "GPU ID {{card}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GPU Memory Utlization (%)",
+          "type": "timeseries"
         }
       ],
-      "title": "GPU Memory Utlization (%)",
-      "type": "timeseries"
+      "title": "GPU - Utilization",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -1008,7 +923,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 16
       },
       "id": 40,
       "panels": [
@@ -1024,15 +939,11 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "axisSoftMax": 100,
                 "axisSoftMin": 0,
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -1041,7 +952,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -1063,7 +973,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   },
                   {
                     "color": "#56A64B",
@@ -1083,7 +994,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 43
+            "y": 17
           },
           "id": 102,
           "options": {
@@ -1131,15 +1042,11 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "axisSoftMax": 100,
                 "axisSoftMin": 0,
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -1148,7 +1055,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -1170,7 +1076,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   },
                   {
                     "color": "#56A64B",
@@ -1190,7 +1097,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 100
+            "y": 26
           },
           "id": 129,
           "options": {
@@ -1238,15 +1145,11 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "axisSoftMax": 100,
                 "axisSoftMin": 0,
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -1255,7 +1158,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -1277,7 +1179,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -1289,7 +1192,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 109
+            "y": 35
           },
           "id": 101,
           "options": {
@@ -1337,15 +1240,11 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "axisSoftMax": 100,
                 "axisSoftMin": 0,
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -1354,7 +1253,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -1376,7 +1274,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -1388,7 +1287,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 118
+            "y": 44
           },
           "id": 114,
           "options": {
@@ -1436,15 +1335,11 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "axisSoftMax": 100,
                 "axisSoftMin": 0,
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -1453,7 +1348,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -1475,7 +1369,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -1487,7 +1382,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 126
+            "y": 52
           },
           "id": 115,
           "options": {
@@ -1533,7 +1428,395 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 17
+      },
+      "id": 131,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${source}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 18
+          },
+          "id": 133,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "right"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "rjpu9PXSz"
+              },
+              "editorMode": "code",
+              "expr": "sum by (card) ({__name__=~\"rocm_ras_.+_correctable_count\",instance=\"$instance\"})",
+              "legendFormat": "{{card}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Correctable Errors by GPU ID",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${source}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 18
+          },
+          "id": 134,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "right"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "rjpu9PXSz"
+              },
+              "editorMode": "code",
+              "expr": "sum by (card) ({__name__=~\"rocm_ras_.+_uncorrectable_count\",instance=\"$instance\"})",
+              "legendFormat": "{{card}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Uncorrectable Errors by GPU ID",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${source}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 26
+          },
+          "id": 135,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "right"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "rjpu9PXSz"
+              },
+              "editorMode": "code",
+              "expr": "sum by (__name__) ({__name__=~\"rocm_ras_.+_correctable_count\",instance=\"$instance\"})",
+              "legendFormat": "{{card}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Correctable Errors by Block",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "rocm_ras_(.*)_correctable_count",
+                "renamePattern": "$1"
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${source}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 26
+          },
+          "id": 136,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "right"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "rjpu9PXSz"
+              },
+              "editorMode": "code",
+              "expr": "sum by (__name__) ({__name__=~\"rocm_ras_.+_uncorrectable_count\",instance=\"$instance\"})",
+              "legendFormat": "{{card}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Uncorrectable Errors by Block",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "rocm_ras_(.*)_uncorrectable_count",
+                "renamePattern": "$1"
+              }
+            }
+          ],
+          "type": "timeseries"
+        }
+      ],
+      "title": "GPU - RAS",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
       },
       "id": 116,
       "panels": [
@@ -1549,13 +1832,9 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -1564,7 +1843,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -1602,7 +1880,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 44
+            "y": 35
           },
           "id": 119,
           "options": {
@@ -1648,15 +1926,11 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "axisSoftMax": 100,
                 "axisSoftMin": 0,
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -1665,7 +1939,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -1704,7 +1977,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 52
+            "y": 43
           },
           "id": 120,
           "options": {
@@ -1748,7 +2021,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 19
       },
       "id": 117,
       "panels": [
@@ -1764,13 +2037,9 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -1779,7 +2048,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -1817,7 +2085,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 343
+            "y": 18
           },
           "id": 121,
           "options": {
@@ -1875,7 +2143,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 20
       },
       "id": 118,
       "panels": [
@@ -1891,13 +2159,9 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -1906,7 +2170,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -1945,7 +2208,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 78
+            "y": 107
           },
           "id": 122,
           "options": {
@@ -2013,13 +2276,9 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -2028,7 +2287,6 @@
                   "tooltip": false,
                   "viz": false
                 },
-                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -2067,7 +2325,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 86
+            "y": 115
           },
           "id": 123,
           "options": {
@@ -2133,7 +2391,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 46
+        "y": 21
       },
       "id": 110,
       "panels": [
@@ -2149,9 +2407,7 @@
               },
               "custom": {
                 "align": "auto",
-                "cellOptions": {
-                  "type": "auto"
-                },
+                "displayMode": "auto",
                 "inspect": false
               },
               "mappings": [],
@@ -2159,7 +2415,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2187,7 +2444,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 394
+            "y": 108
           },
           "id": 111,
           "options": {
@@ -2203,7 +2460,7 @@
             "showHeader": true,
             "sortBy": []
           },
-          "pluginVersion": "11.3.0-76576",
+          "pluginVersion": "8.5.3",
           "targets": [
             {
               "datasource": {
@@ -2291,7 +2548,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 47
+        "y": 22
       },
       "id": 98,
       "panels": [
@@ -2307,9 +2564,7 @@
               },
               "custom": {
                 "align": "auto",
-                "cellOptions": {
-                  "type": "auto"
-                },
+                "displayMode": "auto",
                 "filterable": true,
                 "inspect": false
               },
@@ -2318,7 +2573,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2437,7 +2693,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 403
+            "y": 23
           },
           "id": 99,
           "interval": "5s",
@@ -2454,7 +2710,7 @@
             "showHeader": true,
             "sortBy": []
           },
-          "pluginVersion": "11.3.0-76576",
+          "pluginVersion": "8.5.3",
           "targets": [
             {
               "datasource": {
@@ -2619,9 +2875,8 @@
       "type": "row"
     }
   ],
-  "preload": false,
   "refresh": "",
-  "schemaVersion": 40,
+  "schemaVersion": 36,
   "tags": [
     "omnistat"
   ],
@@ -2630,6 +2885,7 @@
       {
         "hide": 2,
         "includeAll": false,
+        "multi": false,
         "name": "source",
         "options": [],
         "query": "prometheus",
@@ -2651,8 +2907,10 @@
         },
         "definition": "label_values(rocm_num_gpus,instance)",
         "description": "",
+        "hide": 0,
         "includeAll": false,
         "label": "Node",
+        "multi": false,
         "name": "instance",
         "options": [],
         "query": {
@@ -2661,14 +2919,15 @@
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
-        "regex": "/(?<value>(?<text>[\\w\\-\\.]+):[\\d]+)/",
+          "regex": "/(?<value>(?<text>[\\w\\-\\.]+):[\\d]+)/",
+        "skipUrlSync": false,
         "sort": 1,
         "type": "query"
       }
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-2d",
     "to": "now"
   },
   "timepicker": {

--- a/omnistat/collector_smi.py
+++ b/omnistat/collector_smi.py
@@ -332,7 +332,7 @@ class ROCMSMI(Collector):
         self.registerGPUMetric(self.__prefix + "vram_busy_percentage", "gauge", "Memory controller activity (%)")
         # utilization
         self.registerGPUMetric(self.__prefix + "utilization_percentage", "gauge", "GPU use (%)")
-        # RAS events
+        # RAS counts
         self.registerGPUMetric(self.__prefix + "ras_umc_correctable_count", "gauge", "number of correctable RAS events for UMC block (count)")
         self.registerGPUMetric(self.__prefix + "ras_umc_uncorrectable_count", "gauge", "number of uncorrectable RAS events for UMC block (count)")
 

--- a/omnistat/collector_smi.py
+++ b/omnistat/collector_smi.py
@@ -490,7 +490,11 @@ class ROCMSMI(Collector):
             if self.__ecc_ras_monitoring:
                 for key, block in self.__eccBlocks.items():
                     ret = self.__libsmi.rsmi_dev_ecc_count_get(device, block, ctypes.byref(ras_counts))
-                    self.__GPUmetrics[self.__prefix + "ras_%s_correctable_count" % key].labels(card=gpuLabel).set(ras_counts.correctable_err)
-                    self.__GPUmetrics[self.__prefix + "ras_%s_uncorrectable_count" % key].labels(card=gpuLabel).set(ras_counts.uncorrectable_err)
+                    self.__GPUmetrics[self.__prefix + "ras_%s_correctable_count" % key].labels(card=gpuLabel).set(
+                        ras_counts.correctable_err
+                    )
+                    self.__GPUmetrics[self.__prefix + "ras_%s_uncorrectable_count" % key].labels(card=gpuLabel).set(
+                        ras_counts.uncorrectable_err
+                    )
 
         return

--- a/omnistat/collector_smi_v2.py
+++ b/omnistat/collector_smi_v2.py
@@ -30,15 +30,15 @@ collector. This data collector gathers statistics on a per GPU basis and exposes
 metrics with "amdsmi_{metric_name}" with labels for each GPU number. The following
 example highlights example metrics:
 
-amdsmi_vram_total_bytes{card="0"} 3.4342961152e+010
-amdsmi_temperature_celsius{card="0",location="edge"} 42.0
-amdsmi_temperature_memory_celsius{card="0",location="hbm_0"} 46.0
-amdsmi_utilization_percentage{card="0"} 0.0
-amdsmi_vram_used_percentage{card="0"} 0.0
-amdsmi_vram_busy_percentage{card="0"} 22.0
-amdsmi_average_socket_power_watts{card="0"} 35.0
-amdsmi_mlck_clock_mhz{card="0"} 1200.0
-amdsmi_slck_clock_mhz{card="0"} 300.0
+rocm_vram_total_bytes{card="0"} 3.4342961152e+010
+rocm_temperature_celsius{card="0",location="edge"} 42.0
+rocm_temperature_memory_celsius{card="0",location="hbm_0"} 46.0
+rocm_utilization_percentage{card="0"} 0.0
+rocm_vram_used_percentage{card="0"} 0.0
+rocm_vram_busy_percentage{card="0"} 22.0
+rocm_average_socket_power_watts{card="0"} 35.0
+rocm_mlck_clock_mhz{card="0"} 1200.0
+rocm_slck_clock_mhz{card="0"} 300.0
 """
 
 import logging
@@ -66,6 +66,11 @@ def get_gpu_metrics(device):
             continue
         # Average of list values
         elif type(v) is list:
+            if any(isinstance(item,list) for item in v):
+                # Filter list of lists
+                result[k] = 0
+                continue
+
             v = [x for x in v if type(x) not in [bool, str]]
             if not v:
                 # Filter empty lists

--- a/omnistat/collector_smi_v2.py
+++ b/omnistat/collector_smi_v2.py
@@ -100,7 +100,7 @@ def check_min_version(minVersion):
 
 
 class AMDSMI(Collector):
-    def __init__(self):
+    def __init__(self, runtimeConfig = None):
         logging.debug("Initializing AMD SMI data collector")
         self.__prefix = "rocm_"
         self.__schema = 1.0
@@ -111,6 +111,7 @@ class AMDSMI(Collector):
         self.__GPUMetrics = {}
         self.__metricMapping = {}
         self.__dumpMappedMetricsOnly = True
+        self.__ecc_ras_monitoring = runtimeConfig["collector_ras_ecc"]
         self.__eccBlocks = {}
         # verify minimum version met
         check_min_version("24.5.2")
@@ -181,32 +182,33 @@ class AMDSMI(Collector):
         )
 
         # Register RAS ECC related metrics
-        for block in smi.AmdSmiGpuBlock:
-            if block == smi.AmdSmiGpuBlock.INVALID:
-                continue
-            logging.debug("Checking on %s ECC status.." % block)
-            status = smi.amdsmi_get_gpu_ecc_status(self.__devices[0], block)
-            if status == smi.AmdSmiRasErrState.ENABLED:
-                # check if queryable
-                try:
-                    status = smi.amdsmi_get_gpu_ecc_count(self.__devices[0],block)
-                    key = "%s" % block
-                    key = key.removeprefix("AmdSmiGpuBlock.").lower()
-                    self.__eccBlocks[key] = (block)
-                    metric = "ras_%s_correctable_count" % key
-                    self.__GPUMetrics[metric] = Gauge(self.__prefix + metric, 
-                        "number of correctable RAS events for %s block (count)" % key, labelnames=["card"]
-                    )
-                    metric = "ras_%s_uncorrectable_count" % key
-                    self.__GPUMetrics[metric] = Gauge(self.__prefix + metric, 
-                        "number of uncorrectable RAS events for %s block (count)" % key, labelnames=["card"]
-                    )
-                    metric = "ras_%s_deferred_count" % key
-                    self.__GPUMetrics[metric] = Gauge(self.__prefix + metric, 
-                        "number of deferred RAS events for %s block (count)" % key, labelnames=["card"]
-                    )
-                except:
-                    logging.debug("Skipping RAS definition for %s" % block)
+        if self.__ecc_ras_monitoring:
+            for block in smi.AmdSmiGpuBlock:
+                if block == smi.AmdSmiGpuBlock.INVALID:
+                    continue
+                logging.debug("Checking on %s ECC status.." % block)
+                status = smi.amdsmi_get_gpu_ecc_status(self.__devices[0], block)
+                if status == smi.AmdSmiRasErrState.ENABLED:
+                    # check if queryable
+                    try:
+                        status = smi.amdsmi_get_gpu_ecc_count(self.__devices[0],block)
+                        key = "%s" % block
+                        key = key.removeprefix("AmdSmiGpuBlock.").lower()
+                        self.__eccBlocks[key] = (block)
+                        metric = "ras_%s_correctable_count" % key
+                        self.__GPUMetrics[metric] = Gauge(self.__prefix + metric, 
+                            "number of correctable RAS events for %s block (count)" % key, labelnames=["card"]
+                        )
+                        metric = "ras_%s_uncorrectable_count" % key
+                        self.__GPUMetrics[metric] = Gauge(self.__prefix + metric, 
+                            "number of uncorrectable RAS events for %s block (count)" % key, labelnames=["card"]
+                        )
+                        metric = "ras_%s_deferred_count" % key
+                        self.__GPUMetrics[metric] = Gauge(self.__prefix + metric, 
+                            "number of deferred RAS events for %s block (count)" % key, labelnames=["card"]
+                        )
+                    except:
+                        logging.debug("Skipping RAS definition for %s" % block)
 
         # Cache valid primary temperature location and register with location label
         dev0 = self.__devices[0]
@@ -297,12 +299,13 @@ class AMDSMI(Collector):
                 ).set(hbm_temperature)
 
             # RAS counts
-            for key, block in self.__eccBlocks.items():
-                ecc_error_counts = smi.amdsmi_get_gpu_ecc_count(device,block)
-                metric = "ras_%s_correctable_count" % key
-                self.__GPUMetrics["ras_%s_correctable_count" % key].labels(card=cardId).set(ecc_error_counts['correctable_count'])
-                self.__GPUMetrics["ras_%s_uncorrectable_count" % key].labels(card=cardId).set(ecc_error_counts['uncorrectable_count'])
-                self.__GPUMetrics["ras_%s_deferred_count" % key].labels(card=cardId).set(ecc_error_counts['deferred_count'])
+            if self.__ecc_ras_monitoring:
+                for key, block in self.__eccBlocks.items():
+                    ecc_error_counts = smi.amdsmi_get_gpu_ecc_count(device,block)
+                    metric = "ras_%s_correctable_count" % key
+                    self.__GPUMetrics["ras_%s_correctable_count" % key].labels(card=cardId).set(ecc_error_counts['correctable_count'])
+                    self.__GPUMetrics["ras_%s_uncorrectable_count" % key].labels(card=cardId).set(ecc_error_counts['uncorrectable_count'])
+                    self.__GPUMetrics["ras_%s_deferred_count" % key].labels(card=cardId).set(ecc_error_counts['deferred_count'])
 
             # other stats available via get_gpu_metrics
             metrics = get_gpu_metrics(device)

--- a/omnistat/collector_smi_v2.py
+++ b/omnistat/collector_smi_v2.py
@@ -66,7 +66,7 @@ def get_gpu_metrics(device):
             continue
         # Average of list values
         elif type(v) is list:
-            if any(isinstance(item,list) for item in v):
+            if any(isinstance(item, list) for item in v):
                 # Filter list of lists
                 result[k] = 0
                 continue
@@ -100,7 +100,7 @@ def check_min_version(minVersion):
 
 
 class AMDSMI(Collector):
-    def __init__(self, runtimeConfig = None):
+    def __init__(self, runtimeConfig=None):
         logging.debug("Initializing AMD SMI data collector")
         self.__prefix = "rocm_"
         self.__schema = 1.0
@@ -191,21 +191,27 @@ class AMDSMI(Collector):
                 if status == smi.AmdSmiRasErrState.ENABLED:
                     # check if queryable
                     try:
-                        status = smi.amdsmi_get_gpu_ecc_count(self.__devices[0],block)
+                        status = smi.amdsmi_get_gpu_ecc_count(self.__devices[0], block)
                         key = "%s" % block
                         key = key.removeprefix("AmdSmiGpuBlock.").lower()
-                        self.__eccBlocks[key] = (block)
+                        self.__eccBlocks[key] = block
                         metric = "ras_%s_correctable_count" % key
-                        self.__GPUMetrics[metric] = Gauge(self.__prefix + metric, 
-                            "number of correctable RAS events for %s block (count)" % key, labelnames=["card"]
+                        self.__GPUMetrics[metric] = Gauge(
+                            self.__prefix + metric,
+                            "number of correctable RAS events for %s block (count)" % key,
+                            labelnames=["card"],
                         )
                         metric = "ras_%s_uncorrectable_count" % key
-                        self.__GPUMetrics[metric] = Gauge(self.__prefix + metric, 
-                            "number of uncorrectable RAS events for %s block (count)" % key, labelnames=["card"]
+                        self.__GPUMetrics[metric] = Gauge(
+                            self.__prefix + metric,
+                            "number of uncorrectable RAS events for %s block (count)" % key,
+                            labelnames=["card"],
                         )
                         metric = "ras_%s_deferred_count" % key
-                        self.__GPUMetrics[metric] = Gauge(self.__prefix + metric, 
-                            "number of deferred RAS events for %s block (count)" % key, labelnames=["card"]
+                        self.__GPUMetrics[metric] = Gauge(
+                            self.__prefix + metric,
+                            "number of deferred RAS events for %s block (count)" % key,
+                            labelnames=["card"],
                         )
                     except:
                         logging.debug("Skipping RAS definition for %s" % block)
@@ -301,11 +307,17 @@ class AMDSMI(Collector):
             # RAS counts
             if self.__ecc_ras_monitoring:
                 for key, block in self.__eccBlocks.items():
-                    ecc_error_counts = smi.amdsmi_get_gpu_ecc_count(device,block)
+                    ecc_error_counts = smi.amdsmi_get_gpu_ecc_count(device, block)
                     metric = "ras_%s_correctable_count" % key
-                    self.__GPUMetrics["ras_%s_correctable_count" % key].labels(card=cardId).set(ecc_error_counts['correctable_count'])
-                    self.__GPUMetrics["ras_%s_uncorrectable_count" % key].labels(card=cardId).set(ecc_error_counts['uncorrectable_count'])
-                    self.__GPUMetrics["ras_%s_deferred_count" % key].labels(card=cardId).set(ecc_error_counts['deferred_count'])
+                    self.__GPUMetrics["ras_%s_correctable_count" % key].labels(card=cardId).set(
+                        ecc_error_counts["correctable_count"]
+                    )
+                    self.__GPUMetrics["ras_%s_uncorrectable_count" % key].labels(card=cardId).set(
+                        ecc_error_counts["uncorrectable_count"]
+                    )
+                    self.__GPUMetrics["ras_%s_deferred_count" % key].labels(card=cardId).set(
+                        ecc_error_counts["deferred_count"]
+                    )
 
             # other stats available via get_gpu_metrics
             metrics = get_gpu_metrics(device)

--- a/omnistat/config/omnistat.default
+++ b/omnistat/config/omnistat.default
@@ -3,6 +3,7 @@
 port = 8001
 enable_rocm_smi = True
 enable_amd_smi = False
+enable_ras_ecc = True
 enable_rms = False
 
 ## Path to local ROCM install to access SMI library

--- a/omnistat/monitor.py
+++ b/omnistat/monitor.py
@@ -80,6 +80,7 @@ class Monitor:
         self.runtimeConfig["collector_enable_events"] = config["omnistat.collectors"].getboolean("enable_events", False)
         self.runtimeConfig["collector_port"] = config["omnistat.collectors"].get("port", 8001)
         self.runtimeConfig["collector_rocm_path"] = config["omnistat.collectors"].get("rocm_path", "/opt/rocm")
+        self.runtimeConfig["collector_ras_ecc"] = config["omnistat.collectors"].getboolean("enable_ras_ecc", True)
 
         allowed_ips = config["omnistat.collectors"].get("allowed_ips", "127.0.0.1")
         # convert comma-separated string into list
@@ -127,11 +128,11 @@ class Monitor:
         if self.runtimeConfig["collector_enable_rocm_smi"]:
             from omnistat.collector_smi import ROCMSMI
 
-            self.__collectors.append(ROCMSMI(rocm_path=self.runtimeConfig["collector_rocm_path"]))
+            self.__collectors.append(ROCMSMI(runtimeConfig=self.runtimeConfig))
         if self.runtimeConfig["collector_enable_amd_smi"]:
             from omnistat.collector_smi_v2 import AMDSMI
 
-            self.__collectors.append(AMDSMI())
+            self.__collectors.append(AMDSMI(runtimeConfig=self.runtimeConfig))
         if self.runtimeConfig["collector_enable_amd_smi_process"]:
             from omnistat.collector_smi_process import AMDSMIProcess
 


### PR DESCRIPTION
This PR introduces additional gauge metrics within the SMI GPU data collectors to track error counts for specific GPU blocks (both correctable and uncorrectable).  

Examples of new metric definitions are highlighted below.

```
rocm_ras_umc_correctable_count{card="0"} 0.0
rocm_ras_umc_uncorrectable_count{card="0"} 0.0
rocm_ras_sdma_correctable_count{card="0"} 0.0
rocm_ras_sdma_uncorrectable_count{card="0"} 0.0
rocm_ras_gfx_correctable_count{card="0"} 0.0
rocm_ras_gfx_uncorrectable_count{card="0"} 0.0
rocm_ras_mmhub_correctable_count{card="0"} 0.0
rocm_ras_mmhub_uncorrectable_count{card="0"} 0.0
rocm_ras_pcie_bif_correctable_count{card="0"} 0.0
rocm_ras_pcie_bif_uncorrectable_count{card="0"} 0.0
rocm_ras_hdp_correctable_count{card="0"} 0.0
rocm_ras_hdp_uncorrectable_count{card="0"} 0.0
```

Note: these RAS counters are enabled by default, but they can be disabled via the following runtime setting:

```
[omnistat.collectors]
enable_ras_ecc = False
```

These new counters are available for use in either either the `rocm_smi` or `amd_smi` variant of the data collector. Note that the `amd_smi` variant also includes a third "deferred" counter for each supported GPU block, e.g:

```
rocm_ras_umc_correctable_count{card="0"} 0.0
rocm_ras_umc_uncorrectable_count{card="0"} 0.0
rocm_ras_umc_deferred_count{card="0"} 0.0
```
