### PR TITLE
Update formatting actions to newer Ubuntu

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   python:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: [3.9]
@@ -36,7 +36,7 @@ jobs:
       uses: isort/isort-action@master
 
   python-bytecode:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test-user-pull.yml
+++ b/.github/workflows/test-user-pull.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: User-level Omnistat (pull/prometheus)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         execution: [ source, package ]

--- a/.github/workflows/test-user-push.yml
+++ b/.github/workflows/test-user-push.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: User-level Omnistat (push/victoria)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         execution: [ source, package ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: System-level Omnistat
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         execution: [ source, package ]


### PR DESCRIPTION
Ubuntu 20.04 deprecated as of 2025/04/15.