### PR TITLE
add ability to push directly to remote victoria-metrics instance in user-mode sampling

### DIFF
--- a/omnistat/config/omnistat.default
+++ b/omnistat/config/omnistat.default
@@ -36,10 +36,23 @@ system_name = My Snazzy System
 
 ssh_key = ~/.ssh/id_rsa
 
+# how often to push cached data to remote victoria-metrics server
+push_frequency_mins = 5
+
+# settings for pushing data to external victoria-metrics instance (enabled via external_victoria = True)
+
+external_victoria = False
+external_victoria_endpoint = victoria.endpoint.org
+external_victoria_port = 8440
+# external_proxy=http://proxy.myorg.org:3128/
+
+# settings when spinning up a local victoria-metrics instance within a job (enabled via external_victoria = False)
+
 victoria_binary = /path-to-victoria-metrics-install/victoria-metrics-prod
 victoria_datadir = data_prom
 victoria_logfile = vic_server.log
-push_frequency_mins = 5
+
+
 
 ## Bind user-mode Omnistat monitor and VictoriaMetrics to specific cores.
 ## Requires numactl. When these options are not set, no binding is enforced.

--- a/omnistat/omni_util.py
+++ b/omnistat/omni_util.py
@@ -93,12 +93,11 @@ class UserBasedMonitoring:
         who have proxy settings in their runtime environment to access the outside world.
         """
 
-        os.environ.pop("http_proxy",None)
-        os.environ.pop("https_proxy",None)
-        os.environ.pop("all_proxy",None)
+        os.environ.pop("http_proxy", None)
+        os.environ.pop("https_proxy", None)
+        os.environ.pop("all_proxy", None)
 
         return
-
 
     def getRMSHosts(self):
         if self.__rms == "slurm":
@@ -136,7 +135,7 @@ class UserBasedMonitoring:
         section = "omnistat.usermode"
 
         # noop if using an external server
-        use_external_victoria = self.runtimeConfig[section].getboolean("external_victoria",False)
+        use_external_victoria = self.runtimeConfig[section].getboolean("external_victoria", False)
         self.__external_proxy = None
 
         if use_external_victoria:
@@ -392,6 +391,7 @@ class UserBasedMonitoring:
             if self.__external_proxy:
                 additional_env = f"http_proxy={self.__external_proxy}"
 
+<<<<<<< HEAD
             # trying local ssh client implementation
             launch_results = utils.execute_ssh_parallel(
                 command=f"sh -c 'cd {os.getcwd()} && PYTHONPATH={':'.join(sys.path)} {additional_env} {cmd}'",
@@ -401,6 +401,15 @@ class UserBasedMonitoring:
                 max_retries=3,
                 retry_delay=5,
             )
+=======
+            try:
+                output = client.run_command(
+                    f"sh -c 'cd {os.getcwd()} && PYTHONPATH={':'.join(sys.path)} {additional_env} {cmd}'",
+                    stop_on_errors=False,
+                )
+            except:
+                logging.info("Exception thrown launching parallel ssh client")
+>>>>>>> 19c0400 (apply formatting)
 
             # verify exporter available on all nodes...
             if len(self.__hosts) <= 8:

--- a/omnistat/omni_util.py
+++ b/omnistat/omni_util.py
@@ -98,7 +98,7 @@ class UserBasedMonitoring:
 
         section = "omnistat.usermode"
 
-        self.__external_victoria = self.runtimeConfig[section].getboolean("external_victoria",False)
+        self.__external_victoria = self.runtimeConfig[section].getboolean("external_victoria", False)
         if self.__external_victoria:
             logging.info("External VictoriaMetrics server requested")
             self.__external_victoria_endpoint = self.runtimeConfig[section].get("external_victoria_endpoint")
@@ -115,7 +115,6 @@ class UserBasedMonitoring:
         self.__victoriaModeSetup_initialized = True
 
         return
-
 
     def disableProxies(self):
         """

--- a/omnistat/omni_util.py
+++ b/omnistat/omni_util.py
@@ -50,6 +50,7 @@ class UserBasedMonitoring:
         self.timeout = 5  # default scrape timeout in seconds
         self.__hosts = None
         self.__RMS_Detected = False
+        self.__external_proxy = None
 
     def setup(self, configFileArgument):
         self.configFile = utils.findConfigFile(configFileArgument)
@@ -136,7 +137,6 @@ class UserBasedMonitoring:
 
         # noop if using an external server
         use_external_victoria = self.runtimeConfig[section].getboolean("external_victoria", False)
-        self.__external_proxy = None
 
         if use_external_victoria:
             logging.info("Pushing data to external VictoriaMetrics server")
@@ -391,7 +391,6 @@ class UserBasedMonitoring:
             if self.__external_proxy:
                 additional_env = f"http_proxy={self.__external_proxy}"
 
-<<<<<<< HEAD
             # trying local ssh client implementation
             launch_results = utils.execute_ssh_parallel(
                 command=f"sh -c 'cd {os.getcwd()} && PYTHONPATH={':'.join(sys.path)} {additional_env} {cmd}'",
@@ -401,15 +400,6 @@ class UserBasedMonitoring:
                 max_retries=3,
                 retry_delay=5,
             )
-=======
-            try:
-                output = client.run_command(
-                    f"sh -c 'cd {os.getcwd()} && PYTHONPATH={':'.join(sys.path)} {additional_env} {cmd}'",
-                    stop_on_errors=False,
-                )
-            except:
-                logging.info("Exception thrown launching parallel ssh client")
->>>>>>> 19c0400 (apply formatting)
 
             # verify exporter available on all nodes...
             if len(self.__hosts) <= 8:

--- a/omnistat/omni_util.py
+++ b/omnistat/omni_util.py
@@ -109,8 +109,6 @@ class UserBasedMonitoring:
             if self.runtimeConfig.has_option(section, "external_proxy"):
                 self.__external_proxy = self.runtimeConfig[section].get("external_proxy")
                 logging.info("--> external proxy = %s" % self.__external_proxy)
-            else:
-                self.__external_proxy = None
         else:
             logging.info("Local VictoriaMetrics server requested")
 

--- a/omnistat/omni_util.py
+++ b/omnistat/omni_util.py
@@ -25,7 +25,6 @@
 
 import argparse
 import concurrent.futures
-import getpass
 import importlib.resources
 import logging
 import os
@@ -51,6 +50,7 @@ class UserBasedMonitoring:
         self.__hosts = None
         self.__RMS_Detected = False
         self.__external_proxy = None
+        self.__victoriaModeSetup_initialized = False
 
     def setup(self, configFileArgument):
         self.configFile = utils.findConfigFile(configFileArgument)
@@ -86,6 +86,38 @@ class UserBasedMonitoring:
         self.__RMS_Detected = True
 
         return
+
+    def victoriaModeSetup(self):
+        """
+        Initialize VictoraMetrics settings and cache for use by startserver and
+        startexporter methods.
+        """
+        if self.__victoriaModeSetup_initialized:
+            logging.debug("Skipping VictoriaMetrics setup - already initialized")
+            return
+
+        section = "omnistat.usermode"
+
+        self.__external_victoria = self.runtimeConfig[section].getboolean("external_victoria",False)
+        if self.__external_victoria:
+            logging.info("External VictoriaMetrics server requested")
+            self.__external_victoria_endpoint = self.runtimeConfig[section].get("external_victoria_endpoint")
+            self.__external_victoria_port = self.runtimeConfig[section].get("external_victoria_port")
+            logging.info("--> external host = %s" % self.__external_victoria_endpoint)
+            logging.info("--> external port = %s" % self.__external_victoria_port)
+
+            if self.runtimeConfig.has_option(section, "external_proxy"):
+                self.__external_proxy = self.runtimeConfig[section].get("external_proxy")
+                logging.info("--> external proxy = %s" % self.__external_proxy)
+            else:
+                self.__external_proxy = None
+        else:
+            logging.info("Local VictoriaMetrics server requested")
+
+        self.__victoriaModeSetup_initialized = True
+
+        return
+
 
     def disableProxies(self):
         """
@@ -135,23 +167,13 @@ class UserBasedMonitoring:
 
         section = "omnistat.usermode"
 
+        self.victoriaModeSetup()
+
         # noop if using an external server
-        use_external_victoria = self.runtimeConfig[section].getboolean("external_victoria", False)
-
-        if use_external_victoria:
+        if self.__external_victoria:
             logging.info("Pushing data to external VictoriaMetrics server")
-            self.__external_victoria = True
-            self.__external_victoria_endpoint = self.runtimeConfig[section].get("external_victoria_endpoint")
-            self.__external_victoria_port = self.runtimeConfig[section].get("external_victoria_port")
-            logging.info("--> external host = %s" % self.__external_victoria_endpoint)
-            logging.info("--> external port = %s" % self.__external_victoria_port)
-
-            if self.runtimeConfig.has_option(section, "external_proxy"):
-                self.__external_proxy = self.runtimeConfig[section].get("external_proxy")
-                logging.info("--> external proxy = %s" % self.__external_proxy)
             return
         else:
-            self.__external_victoria = False
             logging.info("Starting VictoriaMetrics server on localhost")
 
         vm_binary = self.runtimeConfig[section].get("victoria_binary")
@@ -299,6 +321,7 @@ class UserBasedMonitoring:
 
         self.rmsDetection()
         self.disableProxies()
+        self.victoriaModeSetup()
 
         if victoriaMode:
             if os.path.exists("./exporter.log"):

--- a/omnistat/standalone.py
+++ b/omnistat/standalone.py
@@ -129,6 +129,10 @@ class Standalone:
         logflask = logging.getLogger("werkzeug")
         logflask.setLevel(logging.ERROR)
 
+        # default labels applied to all metrics from this host
+        self.__labelDefaults = self.__instanceLabel + "," + self.__userLabel
+        logging.debug("Default metric labels = %s" % self.__labelDefaults)
+
         # verify victoriaURL is operational and ready to receive queries (poll for a bit if necessary)
         failed = True
         delay_start = 0.05
@@ -176,7 +180,10 @@ class Standalone:
                 if prefix and not metric.name.startswith(prefix):
                     continue
                 for sample in metric.samples:
-                    labels = self.__instanceLabel
+                    if sample.name == "rmsjob_info":
+                        labels = self.__instanceLabel
+                    else:
+                        labels = self.__labelDefaults
                     if sample.labels:
                         for key, value in sample.labels.items():
                             labels += ',%s="%s"' % (key, value)


### PR DESCRIPTION
This PR adds the capability to push data directly to an external victoria-metrics server while collecting telemetry in user-mode (as opposed to spinning up a temporary instance local to the cluster).  The requirements to use this feature assume:

1. all compute nodes participating in the user-mode collection can route outward to the server (either directly or via an http_proxy)
2. victoria-metrics server networking configured to allow incoming requests from compute node IPs (or proxy) on assigned port

Additional runtime options  to enable and control this mode of operation are highlighted as follows:

```
[omnistat.usermode]

external_victoria = True
external_victoria_endpoint = victoria.endpoint.org
external_victoria_port = 8440

# if a local proxy is needed to route externally, uncomment and update the following
# external_proxy=http://proxy.myorg.org:3128/
```