### PR TITLE
Collect network metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ basis). Relevant target metrics include:
   * ROCm driver version
   * GPU type
   * GPU vBIOS version
+* Host network traffic (rx and tx)
 
 The data can be scraped for detailed visualization and analysis via a
 combination of [Prometheus](https://prometheus.io/) /

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -26,6 +26,7 @@ Omnistat provides a set of utilities to aid cluster administrators or individual
   * ROCm driver version
   * GPU type
   * GPU vBIOS version
+* Host network traffic (rx and tx)
 
 To enable scalable collection of these metrics, Omnistat provides a python-based [Prometheus](https://prometheus.io) client that supplies instantaneous metric values on-demand for periodic polling by a companion Prometheus server (or a [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics) server).
 

--- a/omnistat/collector_network.py
+++ b/omnistat/collector_network.py
@@ -51,7 +51,6 @@ class NETWORK(Collector):
         self.__nic_tx_data_paths = {}
         self.__slingshot_buckets = {}
 
-
     def registerMetrics(self):
         """Register metrics of interest"""
 
@@ -60,7 +59,7 @@ class NETWORK(Collector):
         for entry in os.listdir(base_path):
             if entry == "lo":
                 continue
-            nic_dir = os.path.join(base_path,entry)
+            nic_dir = os.path.join(base_path, entry)
             if os.path.isdir(nic_dir):
                 rx_path = os.path.join("%s/statistics/rx_bytes" % nic_dir)
                 if os.path.isfile(rx_path) and os.path.getsize(rx_path) > 0:
@@ -68,19 +67,19 @@ class NETWORK(Collector):
 
                 tx_path = os.path.join("%s/statistics/tx_bytes" % nic_dir)
                 if os.path.isfile(tx_path) and os.path.getsize(tx_path) > 0:
-                    self.__nic_tx_data_paths[entry] = (tx_path)
+                    self.__nic_tx_data_paths[entry] = tx_path
 
         if len(self.__nic_rx_data_paths) > 0:
             logging.debug(self.__nic_rx_data_paths)
-            metricName="rx_bytes"
-            description="Received (bytes)"
-            self.__rx_metric = Gauge(self.__prefix + metricName,description,labelnames=["interface"])
+            metricName = "rx_bytes"
+            description = "Received (bytes)"
+            self.__rx_metric = Gauge(self.__prefix + metricName, description, labelnames=["interface"])
             logging.info("--> [registered] %s -> %s (gauge)" % (metricName, description))
 
         if len(self.__nic_tx_data_paths) > 0:
-            metricName="tx_bytes"
-            description="Transmitted (bytes)"
-            self.__tx_metric = Gauge(self.__prefix + metricName,description,labelnames=["interface"])
+            metricName = "tx_bytes"
+            description = "Transmitted (bytes)"
+            self.__tx_metric = Gauge(self.__prefix + metricName, description, labelnames=["interface"])
             logging.info("--> [registered] %s -> %s (gauge)" % (metricName, description))
 
         base = "/sys"
@@ -107,33 +106,32 @@ class NETWORK(Collector):
                 self.__slingshot_buckets[device_id][kind][int(min_size)] = bucket
 
         if len(self.__slingshot_buckets) > 0:
-            metricName="slingshot_rx_bytes"
-            description="Slingshot Received (bytes)"
+            metricName = "slingshot_rx_bytes"
+            description = "Slingshot Received (bytes)"
             self.__slingshot_rx_metric = Gauge(self.__prefix + metricName, description, labelnames=["interface"])
             logging.info("--> [registered] %s -> %s (gauge)" % (metricName, description))
 
-            metricName="slingshot_tx_bytes"
-            description="Slingshot Transmitted (bytes)"
+            metricName = "slingshot_tx_bytes"
+            description = "Slingshot Transmitted (bytes)"
             self.__slingshot_tx_metric = Gauge(self.__prefix + metricName, description, labelnames=["interface"])
             logging.info("--> [registered] %s -> %s (gauge)" % (metricName, description))
-
 
     def updateMetrics(self):
         """Update registered metrics of interest"""
 
         # Received
-        for nic, path in  self.__nic_rx_data_paths.items():
+        for nic, path in self.__nic_rx_data_paths.items():
             try:
-                with open(path, 'r') as f:
+                with open(path, "r") as f:
                     data = int(f.read().strip())
                     self.__rx_metric.labels(interface=nic).set(data)
             except:
                 pass
 
         # Transmitted
-        for nic, path in  self.__nic_tx_data_paths.items():
+        for nic, path in self.__nic_tx_data_paths.items():
             try:
-                with open(path, 'r') as f:
+                with open(path, "r") as f:
                     data = int(f.read().strip())
                     self.__tx_metric.labels(interface=nic).set(data)
             except:
@@ -145,11 +143,11 @@ class NETWORK(Collector):
                 total = 0
                 for size, file in sizes.items():
                     try:
-                        with open(file, 'r') as f:
+                        with open(file, "r") as f:
                             data = f.read().strip()
                             fields = data.split("@")
                             count = int(fields[0])
-                            total += (count * size)
+                            total += count * size
                     except:
                         pass
 

--- a/omnistat/collector_network.py
+++ b/omnistat/collector_network.py
@@ -81,7 +81,7 @@ class NETWORK(Collector):
             if tx_path.is_file() and tx_path.stat().st_size > 0:
                 self.__net_tx_data_paths[nic_name] = tx_path
 
-        # Slingshot CXI traffic (/sys/class/cxi): store data paths to bucketed
+        # Slingshot CXI traffic (/sys/class/cxi): store data paths to binned
         # telemetry files, indexed by interface ID and minimum size of the
         # bucket. For example, for Rx bandwidth:
         #   __cxi_rx_data_paths = {
@@ -165,6 +165,9 @@ class NETWORK(Collector):
             (self.__cxi_tx_data_paths, self.__tx_metric),
         ]
 
+        # For CXI, estimate lower bound of the total amount of bytes:
+        # aggregate values from all buckets using the minimum packet size of
+        # each bucket.
         for data_paths, metric in cxi_data:
             for nic, buckets in data_paths.items():
                 total = 0

--- a/omnistat/collector_network.py
+++ b/omnistat/collector_network.py
@@ -131,8 +131,8 @@ class NETWORK(Collector):
         # counters, indexed by interface ID and port ID. For example, for Rx
         # bandwidth:
         #   __infiniband_rx_data_paths = {
-        #       "mlx5_0:1": "sys/class/infiniband/mlx5_0/ports/1/counters/port_rcv_data",
-        #       "mlx5_1:1": "sys/class/infiniband/mlx5_1/ports/1/counters/port_rcv_data",
+        #       "mlx5_0:1": "/sys/class/infiniband/mlx5_0/ports/1/counters/port_rcv_data",
+        #       "mlx5_1:1": "/sys/class/infiniband/mlx5_1/ports/1/counters/port_rcv_data",
         #       }
         #   }
         ib_base_path = Path("/sys/class/infiniband")
@@ -230,7 +230,9 @@ class NETWORK(Collector):
                 try:
                     with open(path, "r") as f:
                         data = int(f.read().strip())
-                        metric.labels(device_class="infiniband", interface=nic).set(data)
+                        # Counters for infiniband are reported as "octets divided by 4";
+                        # multiply to collect the expected value in bytes.
+                        metric.labels(device_class="infiniband", interface=nic).set(data * 4)
                 except:
                     pass
 

--- a/omnistat/collector_network.py
+++ b/omnistat/collector_network.py
@@ -1,0 +1,106 @@
+# -------------------------------------------------------------------------------
+# MIT License
+#
+# Copyright (c) 2023 - 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# -------------------------------------------------------------------------------
+
+"""Network monitoring
+
+Implements a prometheus info metric to track network traffic data for interface
+exposed in /sys/class/net
+
+"""
+
+import json
+import logging
+import os
+import platform
+import sys
+
+from prometheus_client import Gauge
+
+import omnistat.utils as utils
+from omnistat.collector_base import Collector
+
+
+class NETWORK(Collector):
+    def __init__(self, annotations=False, jobDetection=None):
+        logging.debug("Initializing networking data collector")
+        self.__prefix = "network_"
+        self.__nic_rx_data_paths = {}
+        self.__nic_tx_data_paths = {}
+        self.__metrics = {}
+
+
+    def registerMetrics(self):
+        """Register metrics of interest"""
+
+        # scan local NICs 
+        base_path = "/sys/class/net"
+        for entry in os.listdir(base_path):
+            if entry == "lo":
+                continue
+            nic_dir = os.path.join(base_path,entry)
+            if os.path.isdir(nic_dir):
+                rx_path = os.path.join("%s/statistics/rx_bytes" % nic_dir)
+                if os.path.isfile(rx_path) and os.path.getsize(rx_path) > 0:
+                    self.__nic_rx_data_paths[entry] = rx_path
+
+                tx_path = os.path.join("%s/statistics/tx_bytes" % nic_dir)
+                if os.path.isfile(tx_path) and os.path.getsize(tx_path) > 0:
+                    self.__nic_tx_data_paths[entry] = (tx_path)                    
+
+        if len(self.__nic_rx_data_paths) > 0:
+            logging.debug(self.__nic_rx_data_paths)
+            metricName="rx_bytes"
+            description="Received (bytes)"
+            self.__rx_metric = Gauge(self.__prefix + metricName,description,labelnames=["interface"])
+            logging.info("--> [registered] %s -> %s (gauge)" % (metricName, description))
+
+        if len(self.__nic_tx_data_paths) > 0:
+            metricName="tx_bytes"
+            description="Transmitted (bytes)"
+            self.__tx_metric = Gauge(self.__prefix + metricName,description,labelnames=["interface"])
+            logging.info("--> [registered] %s -> %s (gauge)" % (metricName, description))                        
+            
+
+    def updateMetrics(self):
+        """Update registered metrics of interest"""
+        
+        # Received
+        for nic, path in  self.__nic_rx_data_paths.items():
+            try:
+                with open(path, 'r') as f:
+                    data = int(f.read().strip())
+                    self.__rx_metric.labels(interface=nic).set(data)
+            except:
+                pass
+
+        # Transmitted
+        for nic, path in  self.__nic_tx_data_paths.items():
+            try:
+                with open(path, 'r') as f:
+                    data = int(f.read().strip())
+                    self.__tx_metric.labels(interface=nic).set(data)
+            except:
+                pass             
+
+        return

--- a/omnistat/collector_network.py
+++ b/omnistat/collector_network.py
@@ -50,13 +50,12 @@ class NETWORK(Collector):
         self.__nic_rx_data_paths = {}
         self.__nic_tx_data_paths = {}
         self.__slingshot_buckets = {}
-        self.__metrics = {}
 
 
     def registerMetrics(self):
         """Register metrics of interest"""
 
-        # scan local NICs 
+        # scan local NICs
         base_path = "/sys/class/net"
         for entry in os.listdir(base_path):
             if entry == "lo":
@@ -69,7 +68,7 @@ class NETWORK(Collector):
 
                 tx_path = os.path.join("%s/statistics/tx_bytes" % nic_dir)
                 if os.path.isfile(tx_path) and os.path.getsize(tx_path) > 0:
-                    self.__nic_tx_data_paths[entry] = (tx_path)                    
+                    self.__nic_tx_data_paths[entry] = (tx_path)
 
         if len(self.__nic_rx_data_paths) > 0:
             logging.debug(self.__nic_rx_data_paths)
@@ -82,7 +81,7 @@ class NETWORK(Collector):
             metricName="tx_bytes"
             description="Transmitted (bytes)"
             self.__tx_metric = Gauge(self.__prefix + metricName,description,labelnames=["interface"])
-            logging.info("--> [registered] %s -> %s (gauge)" % (metricName, description))                        
+            logging.info("--> [registered] %s -> %s (gauge)" % (metricName, description))
 
         base = "/sys"
         device_pattern = "class/cxi/cxi*"
@@ -121,7 +120,7 @@ class NETWORK(Collector):
 
     def updateMetrics(self):
         """Update registered metrics of interest"""
-        
+
         # Received
         for nic, path in  self.__nic_rx_data_paths.items():
             try:
@@ -138,7 +137,7 @@ class NETWORK(Collector):
                     data = int(f.read().strip())
                     self.__tx_metric.labels(interface=nic).set(data)
             except:
-                pass             
+                pass
 
         # Slingshot
         for device_id, kinds in self.__slingshot_buckets.items():

--- a/omnistat/collector_network.py
+++ b/omnistat/collector_network.py
@@ -46,7 +46,7 @@ class NETWORK(Collector):
     def __init__(self, annotations=False, jobDetection=None):
         logging.debug("Initializing networking data collector")
 
-        self.__prefix = "network_"
+        self.__prefix = "omnistat_network_"
 
         # Files to check for IP devices.
         self.__net_rx_data_paths = {}

--- a/omnistat/config/omnistat.default
+++ b/omnistat/config/omnistat.default
@@ -5,6 +5,7 @@ enable_rocm_smi = True
 enable_amd_smi = False
 enable_ras_ecc = True
 enable_rms = False
+enable_networking = True
 
 ## Path to local ROCM install to access SMI library
 rocm_path = /opt/rocm

--- a/omnistat/monitor.py
+++ b/omnistat/monitor.py
@@ -130,6 +130,7 @@ class Monitor:
 
         if self.runtimeConfig["collector_enable_networking"]:
             from omnistat.collector_network import NETWORK
+
             self.__collectors.append(NETWORK())
 
         if self.runtimeConfig["collector_enable_rocm_smi"]:

--- a/omnistat/monitor.py
+++ b/omnistat/monitor.py
@@ -65,6 +65,9 @@ class Monitor:
         self.runtimeConfig["collector_enable_amd_smi"] = config["omnistat.collectors"].getboolean(
             "enable_amd_smi", False
         )
+        self.runtimeConfig["collector_enable_networking"] = config["omnistat.collectors"].getboolean(
+            "enable_networking", True
+        )
 
         # verify only one SMI collector is enabled
         if self.runtimeConfig["collector_enable_rocm_smi"] and self.runtimeConfig["collector_enable_amd_smi"]:
@@ -124,6 +127,10 @@ class Monitor:
         return
 
     def initMetrics(self):
+
+        if self.runtimeConfig["collector_enable_networking"]:
+            from omnistat.collector_network import NETWORK
+            self.__collectors.append(NETWORK())
 
         if self.runtimeConfig["collector_enable_rocm_smi"]:
             from omnistat.collector_smi import ROCMSMI


### PR DESCRIPTION
Support network metrics based on sysfs data. 

Remaining tasks:
- [x] Standard network support.
- [x] Slingshot CXI support.
- [x] Infiniband support.
- [x] Decide metric format.
- [x] Update dashboards to include network Ethernet bandwidth. #168.

