### PR TITLE
add metric to track power-cap settings and user-supplied figure-of-merit

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ basis). Relevant target metrics include:
   * ROCm driver version
   * GPU type
   * GPU vBIOS version
-* RAS information [optional]:
-  * Error counts per GPU block
-* GPU power caps [optional]
-* GPU throttling events [optional]
-* Host network traffic (rx and tx) [optional]
+
+#### Additional optional metrics:
+
+* RAS information (error counts per GPU block)
+* GPU power caps
+* GPU throttling events
+* Host network traffic (rx and tx)
 
 
 The data can be scraped for detailed visualization and analysis via a

--- a/README.md
+++ b/README.md
@@ -16,19 +16,22 @@ job. Omnistat infrastructure can aid in the collection of key
 telemetry from AMD Instinct™ accelerators (on a per-GPU
 basis). Relevant target metrics include:
 
-* GPU utilization (occupancy)
+* GPU utilization
 * High-bandwidth memory (HBM) usage
 * GPU power
 * GPU temperature
 * GPU clock frequency
 * GPU memory clock frequency
-* GPU block error counts
-* GPU throttling events
 * Inventory information
   * ROCm driver version
   * GPU type
   * GPU vBIOS version
-* Host network traffic (rx and tx)
+* RAS information [optional]:
+  * Error counts per GPU block
+* GPU power caps [optional]
+* GPU throttling events [optional]
+* Host network traffic (rx and tx) [optional]
+
 
 The data can be scraped for detailed visualization and analysis via a
 combination of [Prometheus](https://prometheus.io/) /

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -14,19 +14,21 @@ Welcome to the documentation area for the **Omnistat** project.  Use the navigat
 
 Omnistat provides a set of utilities to aid cluster administrators or individual application developers to aggregate scale-out system metrics via low-overhead sampling across all hosts in a cluster or, alternatively on a subset of hosts associated with a specific user job. At its core, Omnistat was designed to aid collection of key telemetry from AMD Instinct(tm) accelerators (on a per-GPU basis). Relevant target metrics include:
 
-* GPU utilization (occupancy)
+* GPU utilization
 * High-bandwidth memory (HBM) usage
 * GPU power
-* GPU temperature(s)
+* GPU temperature
 * GPU clock frequency
 * GPU memory clock frequency
-* RAS information:
-  * Error counts per GPU block
 * Inventory information:
   * ROCm driver version
   * GPU type
   * GPU vBIOS version
-* Host network traffic (rx and tx)
+* RAS information [optional]:
+  * Error counts per GPU block
+* GPU power caps [optional]
+* GPU throttling events [optional]
+* Host network traffic (rx and tx) [optional]
 
 To enable scalable collection of these metrics, Omnistat provides a python-based [Prometheus](https://prometheus.io) client that supplies instantaneous metric values on-demand for periodic polling by a companion Prometheus server (or a [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics) server).
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -24,11 +24,12 @@ Omnistat provides a set of utilities to aid cluster administrators or individual
   * ROCm driver version
   * GPU type
   * GPU vBIOS version
-* RAS information [optional]:
-  * Error counts per GPU block
-* GPU power caps [optional]
-* GPU throttling events [optional]
-* Host network traffic (rx and tx) [optional]
+#### Additional optional metrics:
+* RAS information (error counts per GPU block)
+* GPU power caps
+* GPU throttling events
+* Host network traffic (received/transmitted)
+
 
 To enable scalable collection of these metrics, Omnistat provides a python-based [Prometheus](https://prometheus.io) client that supplies instantaneous metric values on-demand for periodic polling by a companion Prometheus server (or a [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics) server).
 

--- a/omnistat/collector_smi.py
+++ b/omnistat/collector_smi.py
@@ -371,7 +371,7 @@ class ROCMSMI(Collector):
                         )
         # power cap
         if self.__power_cap_monitoring:
-            self.registerGPUMetric(self.__prefix + "power_cap_watts", "gauge", "Max power cap of device (W)" )
+            self.registerGPUMetric(self.__prefix + "power_cap_watts", "gauge", "Max power cap of device (W)")
 
         return
 
@@ -504,7 +504,7 @@ class ROCMSMI(Collector):
             # power cap
             if self.__power_cap_monitoring:
                 metric = self.__prefix + "power_cap_watts"
-                ret = self.__libsmi.rsmi_dev_power_cap_get (device, 0x0, ctypes.byref(power))
+                ret = self.__libsmi.rsmi_dev_power_cap_get(device, 0x0, ctypes.byref(power))
                 # rsmi value in microwatts -> convert to watt
                 self.__GPUmetrics[metric].labels(card=gpuLabel).set(power.value / 1000000)
 

--- a/omnistat/collector_smi.py
+++ b/omnistat/collector_smi.py
@@ -368,6 +368,8 @@ class ROCMSMI(Collector):
                         self.registerGPUMetric(
                             metric, "gauge", "number of uncorrectable RAS events for %s block (count)" % key
                         )
+        # power cap
+        self.registerGPUMetric(self.__prefix + "power_cap_watts", "gauge", "Max power cap of device (W)" )
 
         return
 
@@ -496,5 +498,11 @@ class ROCMSMI(Collector):
                     self.__GPUmetrics[self.__prefix + "ras_%s_uncorrectable_count" % key].labels(card=gpuLabel).set(
                         ras_counts.uncorrectable_err
                     )
+            # --
+            # power cap
+            metric = self.__prefix + "power_cap_watts"
+            ret = self.__libsmi.rsmi_dev_power_cap_get (device, 0x0, ctypes.byref(power))
+            # rsmi value in microwatts -> convert to watt
+            self.__GPUmetrics[metric].labels(card=gpuLabel).set(power.value / 1000000)
 
         return

--- a/omnistat/collector_smi_v2.py
+++ b/omnistat/collector_smi_v2.py
@@ -340,6 +340,6 @@ class AMDSMI(Collector):
             # power-capping
             if self.__power_cap_monitoring:
                 power_info = smi.amdsmi_get_power_cap_info(device)
-                self.__GPUMetrics["power_cap_watts"].labels(card=cardId).set(power_info['power_cap']/ 1000000)
+                self.__GPUMetrics["power_cap_watts"].labels(card=cardId).set(power_info["power_cap"] / 1000000)
 
         return

--- a/omnistat/collector_smi_v2.py
+++ b/omnistat/collector_smi_v2.py
@@ -271,6 +271,12 @@ class AMDSMI(Collector):
                 # add Gauge metric only once
                 if metric_name not in self.__GPUMetrics.keys():
                     self.__GPUMetrics[metric_name] = Gauge(metric_name, f"{metric}", labelnames=["card"])
+
+        # Register power capping setting
+        self.__GPUMetrics["power_cap_watts"] = Gauge(
+            self.__prefix + "power_cap_watts", "Max power cap of device (W)", labelnames=["card"]
+        )
+
         return
 
     def updateMetrics(self):
@@ -329,5 +335,8 @@ class AMDSMI(Collector):
                     self.__GPUMetrics["ras_%s_deferred_count" % key].labels(card=cardId).set(
                         ecc_error_counts["deferred_count"]
                     )
+            # power-capping
+            power_info = smi.amdsmi_get_power_cap_info(device)
+            self.__GPUMetrics["power_cap_watts"].labels(card=cardId).set(power_info['power_cap']/ 1000000)
 
         return

--- a/omnistat/monitor.py
+++ b/omnistat/monitor.py
@@ -84,7 +84,9 @@ class Monitor:
         self.runtimeConfig["collector_port"] = config["omnistat.collectors"].get("port", 8001)
         self.runtimeConfig["collector_rocm_path"] = config["omnistat.collectors"].get("rocm_path", "/opt/rocm")
         self.runtimeConfig["collector_ras_ecc"] = config["omnistat.collectors"].getboolean("enable_ras_ecc", True)
-        self.runtimeConfig["collector_power_capping"] = config["omnistat.collectors"].getboolean("enable_power_cap", False)
+        self.runtimeConfig["collector_power_capping"] = config["omnistat.collectors"].getboolean(
+            "enable_power_cap", False
+        )
 
         allowed_ips = config["omnistat.collectors"].get("allowed_ips", "127.0.0.1")
         # convert comma-separated string into list

--- a/omnistat/monitor.py
+++ b/omnistat/monitor.py
@@ -84,6 +84,7 @@ class Monitor:
         self.runtimeConfig["collector_port"] = config["omnistat.collectors"].get("port", 8001)
         self.runtimeConfig["collector_rocm_path"] = config["omnistat.collectors"].get("rocm_path", "/opt/rocm")
         self.runtimeConfig["collector_ras_ecc"] = config["omnistat.collectors"].getboolean("enable_ras_ecc", True)
+        self.runtimeConfig["collector_power_capping"] = config["omnistat.collectors"].getboolean("enable_power_cap", False)
 
         allowed_ips = config["omnistat.collectors"].get("allowed_ips", "127.0.0.1")
         # convert comma-separated string into list

--- a/omnistat/standalone.py
+++ b/omnistat/standalone.py
@@ -172,15 +172,12 @@ class Standalone:
                 if prefix and not metric.name.startswith(prefix):
                     continue
                 for sample in metric.samples:
-                    # labels = 'instance="%s"' % self.__hostname
                     labels = self.__instanceLabel
                     if sample.labels:
                         for key, value in sample.labels.items():
                             labels += ',%s="%s"' % (key, value)
                     entry = "%s{%s} %s %i" % (sample.name, labels, sample.value, timestamp_millisecs)
                     self.__dataVM.append(entry)
-                    # if token == "rmsjob_annotations":
-                    #     print("%s: %s" % (timestamp, sample.value))
 
     def polling(self, monitor, interval_secs):
         """main polling function"""
@@ -238,7 +235,7 @@ class Standalone:
                         with fomLock:
                             for entry in fomData:
                                 entry = '%s{instance="%s",name="%s"} %s %i' % (
-                                    "fom",
+                                    "omnistat_fom",
                                     self.__hostname,
                                     entry["name"],
                                     entry["value"],
@@ -273,7 +270,7 @@ class Standalone:
             with fomLock:
                 for entry in fomData:
                     entry = '%s{instance="%s",name="%s"} %s %i' % (
-                        "fom",
+                        "omnistat_fom",
                         self.__hostname,
                         entry["name"],
                         entry["value"],

--- a/omnistat/standalone.py
+++ b/omnistat/standalone.py
@@ -117,10 +117,12 @@ class Standalone:
         self.__fomCheckFrequencySecs = config["omnistat.usermode"].getint("fom_check_frequency_secs", 10)
         if self.__fomCheckFrequencySecs < 5:
             logging.error("")
-            logging.error("[ERROR]: Please set fom_check_freqeuncy_secs  >= 5 seconds (%s)" % self.__fomCheckFrequencySecs)
+            logging.error(
+                "[ERROR]: Please set fom_check_freqeuncy_secs  >= 5 seconds (%s)" % self.__fomCheckFrequencySecs
+            )
             sys.exit(1)
 
-        logflask = logging.getLogger('werkzeug')
+        logflask = logging.getLogger("werkzeug")
         logflask.setLevel(logging.ERROR)
 
         # verify victoriaURL is operational and ready to receive queries (poll for a bit if necessary)
@@ -235,7 +237,13 @@ class Standalone:
                     if fomData:
                         with fomLock:
                             for entry in fomData:
-                                entry = "%s{instance=\"%s\",name=\"%s\"} %s %i" % ("fom",self.__hostname,entry["name"],entry["value"],entry["timestamp_msecs"])
+                                entry = '%s{instance="%s",name="%s"} %s %i' % (
+                                    "fom",
+                                    self.__hostname,
+                                    entry["name"],
+                                    entry["value"],
+                                    entry["timestamp_msecs"],
+                                )
                                 self.__dataVM.append(entry)
                             logging.info("Registered %i sample(s) of FOM data" % len(fomData))
                             num_fom_samples += len(fomData)
@@ -264,7 +272,13 @@ class Standalone:
         if fomData:
             with fomLock:
                 for entry in fomData:
-                    entry = "%s{instance=\"%s\",name=\"%s\"} %s %i" % ("fom",self.__hostname,entry["name"],entry["value"],entry["timestamp_msecs"])
+                    entry = '%s{instance="%s",name="%s"} %s %i' % (
+                        "fom",
+                        self.__hostname,
+                        entry["name"],
+                        entry["value"],
+                        entry["timestamp_msecs"],
+                    )
                     self.__dataVM.append(entry)
                 logging.info("Registered %i sample(s) of FOM data" % len(fomData))
                 num_fom_samples += len(fomData)
@@ -342,21 +356,22 @@ def terminate():
 def forbidden(e):
     return jsonify(error="Access denied"), 403
 
-@app.route("/fom", methods=['POST'])
+
+@app.route("/fom", methods=["POST"])
 def figureOfMerit():
     """Endpoint that can be used by user to provide application figure of merit"""
     try:
         data = request.get_json()
-        name = data.get('name')
+        name = data.get("name")
         timestamp_msecs = int(datetime.now(timezone.utc).timestamp() * 1000.0)
-        value = data.get('value')
+        value = data.get("value")
         with fomLock:
-            fomData.append({"name":name,"value":value,"timestamp_msecs":timestamp_msecs})
-                            #[value,timestamp_msecs])
+            fomData.append({"name": name, "value": value, "timestamp_msecs": timestamp_msecs})
         return jsonify({"status": "ok"}), 200
-    
+
     except Exception as e:
         return jsonify({"error": str(e)}), 400
+
 
 @app.route("/metrics")
 def heartbeat():


### PR DESCRIPTION
This PR adds two new functionalities:

#### (1) power cap metrics 

New (optional) metrics to track current power cap settings in watts. Example metrics from MI300X are highlighted as follows:

```
rocm_power_cap_watts{card="3"} 1000.0
rocm_power_cap_watts{card="2"} 1000.0
rocm_power_cap_watts{card="0"} 1000.0
rocm_power_cap_watts{card="5"} 1000.0
rocm_power_cap_watts{card="7"} 1000.0
rocm_power_cap_watts{card="6"} 1000.0
rocm_power_cap_watts{card="4"} 1000.0
```

These metrics can be enabled via the following runtime option:

```
[omnistat.collectors]

enable_power_cap = True
```

This new metric addition applies to both system and user-mode usage.

------

#### (2) application figure-of-merit (FOM)

Add ability to supply application figure-of-merit (FOM) data to Omnistat during **user-mode** execution.  This allows applications to provide their own application performance metrics to omnistat during execution.  This can be useful when combined with power cap monitoring of the above metrics to explore the impact on application performance.   To support this functionality, the standalone user-mode data collector adds a new API endpoint called `fom` that can be used to supply a FOM datapoint in JSON format to supply two items:
  * name: the desired name of the FOM
  * value: the current value of the FOM

To demonstrate, the `curl` command-line utility can be used to provide a datapoint as follows:

```
curl -X POST http://localhost:8001/fom -H "Content-Type: application/json" -d '{"name": "avalue", "value": 12.34}'
```

For C/C++ codes, in practice it is often more convenient to leverage `libcurl` to supply the relevant data directly while executing the application.

When using this option, the resulting FOM will be exposed as a Gauge metric that is queryable from Grafana with the user-supplied name included as a metric label, e.g.:

```
omnistat_fom{instance="c1",name="gflops"} = 4584.34
```