### PR TITLE
Track CU Occupancy

### DIFF
--- a/docker/grafana/json-models/job.json
+++ b/docker/grafana/json-models/job.json
@@ -1351,7 +1351,7 @@
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 82
+            "y": 30
           },
           "id": 27,
           "interval": "$interval",
@@ -1461,7 +1461,7 @@
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 82
+            "y": 30
           },
           "id": 87,
           "interval": "$interval",
@@ -1612,7 +1612,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 93
+            "y": 273
           },
           "id": 90,
           "interval": "$interval",
@@ -1695,7 +1695,7 @@
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 1086
+            "y": 2909
           },
           "id": 88,
           "interval": "$interval",
@@ -1805,7 +1805,7 @@
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 1086
+            "y": 2909
           },
           "id": 89,
           "interval": "$interval",
@@ -1955,7 +1955,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1113
+            "y": 2936
           },
           "id": 91,
           "interval": "$interval",
@@ -2030,7 +2030,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "#EAB839",
@@ -2050,7 +2051,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 1122
+            "y": 1068
           },
           "id": 28,
           "interval": "$interval",
@@ -2069,7 +2070,7 @@
             "showThresholdMarkers": true,
             "sizing": "auto"
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -2112,7 +2113,7 @@
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 1122
+            "y": 1068
           },
           "id": 86,
           "interval": "$interval",
@@ -2168,7 +2169,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -2205,7 +2206,8 @@
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "#EAB839",
@@ -2225,7 +2227,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 1810
+            "y": 1076
           },
           "id": 29,
           "interval": "$interval",
@@ -2244,7 +2246,7 @@
             "showThresholdMarkers": true,
             "sizing": "auto"
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -2287,7 +2289,7 @@
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 1810
+            "y": 1076
           },
           "id": 31,
           "interval": "$interval",
@@ -2343,7 +2345,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -2412,7 +2414,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2428,7 +2431,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1818
+            "y": 1084
           },
           "id": 24,
           "interval": "$interval",
@@ -2440,12 +2443,13 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -2649,7 +2653,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 1123
+            "y": 2946
           },
           "id": 52,
           "interval": "$interval",
@@ -2851,7 +2855,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 1188
+            "y": 3011
           },
           "id": 97,
           "interval": "$interval",
@@ -3087,7 +3091,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 1188
+            "y": 3011
           },
           "id": 98,
           "interval": "$interval",
@@ -3266,7 +3270,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 1197
+            "y": 3020
           },
           "id": 95,
           "interval": "$interval",
@@ -3489,7 +3493,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 1467
+            "y": 3290
           },
           "id": 54,
           "interval": "$interval",
@@ -3693,7 +3697,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 1467
+            "y": 3290
           },
           "id": 99,
           "interval": "$interval",
@@ -3856,7 +3860,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 1476
+            "y": 3299
           },
           "id": 100,
           "interval": "$interval",
@@ -4017,7 +4021,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4033,7 +4038,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1125
+            "y": 35
           },
           "id": 33,
           "interval": "$interval",
@@ -4117,7 +4122,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4133,7 +4139,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1133
+            "y": 83
           },
           "id": 104,
           "interval": "$interval",
@@ -4217,7 +4223,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4233,7 +4240,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1141
+            "y": 91
           },
           "id": 22,
           "interval": "$interval",
@@ -4333,7 +4340,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1149
+            "y": 99
           },
           "id": 25,
           "interval": "$interval",
@@ -4433,7 +4440,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1149
+            "y": 99
           },
           "id": 23,
           "interval": "$interval",
@@ -4470,7 +4477,7 @@
           "type": "timeseries"
         }
       ],
-      "title": "GPU Telemetry: GPU IDs",
+      "title": "GPU Telemetry - GPU IDs",
       "type": "row"
     },
     {
@@ -4480,6 +4487,131 @@
         "w": 24,
         "x": 0,
         "y": 35
+      },
+      "id": 123,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${source}"
+          },
+          "description": "Estimated CU occupancy based on the number of in-flight waves of all processes running in each GPU. In-flight waves are translated into number of occupied compute units based on the maximum number of waves per CU. This estimate doesn't account for how waves are distributed, and is not always a good measure of performance.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 36
+          },
+          "id": 125,
+          "interval": "$interval",
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "maxHeight": 600,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${source}"
+              },
+              "editorMode": "code",
+              "expr": "(rocm_compute_unit_occupancy * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"}) * 100 / (rocm_num_compute_units * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
+              "instant": false,
+              "legendFormat": "{{instance}}, {{card}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GPU CU Occupancy (%)",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "([^,:]+)(?:[:].*)?, (.+)",
+                "renamePattern": "GPU: $1/$2"
+              }
+            }
+          ],
+          "type": "timeseries"
+        }
+      ],
+      "title": "GPU Compute Unit Occupancy - GPUs",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 36
       },
       "id": 122,
       "panels": [
@@ -4549,7 +4681,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 44
+            "y": 61
           },
           "id": 120,
           "options": {
@@ -4746,7 +4878,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 44
+            "y": 61
           },
           "id": 121,
           "options": {
@@ -4887,7 +5019,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 39
       },
       "id": 101,
       "panels": [
@@ -4939,8 +5071,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4956,7 +5087,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 922
+            "y": 2745
           },
           "id": 105,
           "interval": "$interval",
@@ -5049,8 +5180,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5066,7 +5196,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 922
+            "y": 2745
           },
           "id": 106,
           "interval": "$interval",
@@ -5121,7 +5251,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 40
       },
       "id": 41,
       "panels": [
@@ -5189,7 +5319,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 951
+            "y": 2774
           },
           "id": 116,
           "interval": "$interval",
@@ -5298,7 +5428,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 951
+            "y": 2774
           },
           "id": 117,
           "interval": "$interval",
@@ -5353,7 +5483,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 42
       },
       "id": 57,
       "panels": [
@@ -5460,7 +5590,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2863
+            "y": 4686
           },
           "id": 56,
           "interval": "$interval",
@@ -5553,7 +5683,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 43
       },
       "id": 111,
       "panels": [
@@ -5684,7 +5814,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 978
+            "y": 2801
           },
           "id": 107,
           "interval": "$interval",
@@ -5879,7 +6009,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 978
+            "y": 2801
           },
           "id": 112,
           "interval": "$interval",
@@ -6038,7 +6168,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 986
+            "y": 2809
           },
           "id": 108,
           "interval": "$interval",
@@ -6266,7 +6396,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 986
+            "y": 2809
           },
           "id": 113,
           "interval": "$interval",
@@ -6421,7 +6551,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 994
+            "y": 2817
           },
           "id": 109,
           "interval": "$interval",
@@ -6649,7 +6779,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 994
+            "y": 2817
           },
           "id": 115,
           "interval": "$interval",
@@ -6805,7 +6935,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1002
+            "y": 2825
           },
           "id": 110,
           "interval": "$interval",
@@ -7029,7 +7159,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1002
+            "y": 2825
           },
           "id": 114,
           "interval": "$interval",

--- a/grafana/json-models/system/rms-job.json
+++ b/grafana/json-models/system/rms-job.json
@@ -1759,7 +1759,7 @@
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 82
+            "y": 30
           },
           "id": 27,
           "interval": "$interval",
@@ -1869,7 +1869,7 @@
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 82
+            "y": 30
           },
           "id": 87,
           "interval": "$interval",
@@ -2020,7 +2020,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 93
+            "y": 273
           },
           "id": 90,
           "interval": "$interval",
@@ -2103,7 +2103,7 @@
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 1086
+            "y": 2909
           },
           "id": 88,
           "interval": "$interval",
@@ -2213,7 +2213,7 @@
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 1086
+            "y": 2909
           },
           "id": 89,
           "interval": "$interval",
@@ -2363,7 +2363,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1113
+            "y": 2936
           },
           "id": 91,
           "interval": "$interval",
@@ -2438,7 +2438,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "#EAB839",
@@ -2458,7 +2459,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 1122
+            "y": 1068
           },
           "id": 28,
           "interval": "$interval",
@@ -2477,7 +2478,7 @@
             "showThresholdMarkers": true,
             "sizing": "auto"
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -2520,7 +2521,7 @@
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 1122
+            "y": 1068
           },
           "id": 86,
           "interval": "$interval",
@@ -2576,7 +2577,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -2613,7 +2614,8 @@
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "#EAB839",
@@ -2633,7 +2635,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 1810
+            "y": 1076
           },
           "id": 29,
           "interval": "$interval",
@@ -2652,7 +2654,7 @@
             "showThresholdMarkers": true,
             "sizing": "auto"
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -2695,7 +2697,7 @@
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 1810
+            "y": 1076
           },
           "id": 31,
           "interval": "$interval",
@@ -2751,7 +2753,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -2820,7 +2822,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2836,7 +2839,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1818
+            "y": 1084
           },
           "id": 24,
           "interval": "$interval",
@@ -2848,12 +2851,13 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -3057,7 +3061,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 1123
+            "y": 2946
           },
           "id": 52,
           "interval": "$interval",
@@ -3259,7 +3263,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 1188
+            "y": 3011
           },
           "id": 97,
           "interval": "$interval",
@@ -3495,7 +3499,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 1188
+            "y": 3011
           },
           "id": 98,
           "interval": "$interval",
@@ -3674,7 +3678,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 1197
+            "y": 3020
           },
           "id": 95,
           "interval": "$interval",
@@ -3897,7 +3901,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 1467
+            "y": 3290
           },
           "id": 54,
           "interval": "$interval",
@@ -4101,7 +4105,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 1467
+            "y": 3290
           },
           "id": 99,
           "interval": "$interval",
@@ -4264,7 +4268,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 1476
+            "y": 3299
           },
           "id": 100,
           "interval": "$interval",
@@ -4425,7 +4429,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4441,7 +4446,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1125
+            "y": 35
           },
           "id": 33,
           "interval": "$interval",
@@ -4525,7 +4530,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4541,7 +4547,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1133
+            "y": 83
           },
           "id": 104,
           "interval": "$interval",
@@ -4625,7 +4631,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4641,7 +4648,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1141
+            "y": 91
           },
           "id": 22,
           "interval": "$interval",
@@ -4741,7 +4748,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1149
+            "y": 99
           },
           "id": 25,
           "interval": "$interval",
@@ -4841,7 +4848,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1149
+            "y": 99
           },
           "id": 23,
           "interval": "$interval",
@@ -4878,7 +4885,7 @@
           "type": "timeseries"
         }
       ],
-      "title": "GPU Telemetry: GPU IDs",
+      "title": "GPU Telemetry - GPU IDs",
       "type": "row"
     },
     {
@@ -4888,6 +4895,131 @@
         "w": 24,
         "x": 0,
         "y": 35
+      },
+      "id": 123,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${source}"
+          },
+          "description": "Estimated CU occupancy based on the number of in-flight waves of all processes running in each GPU. In-flight waves are translated into number of occupied compute units based on the maximum number of waves per CU. This estimate doesn't account for how waves are distributed, and is not always a good measure of performance.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 36
+          },
+          "id": 125,
+          "interval": "$interval",
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "maxHeight": 600,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${source}"
+              },
+              "editorMode": "code",
+              "expr": "(rocm_compute_unit_occupancy * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"}) * 100 / (rocm_num_compute_units * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
+              "instant": false,
+              "legendFormat": "{{instance}}, {{card}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GPU CU Occupancy (%)",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "([^,:]+)(?:[:].*)?, (.+)",
+                "renamePattern": "GPU: $1/$2"
+              }
+            }
+          ],
+          "type": "timeseries"
+        }
+      ],
+      "title": "GPU Compute Unit Occupancy - GPUs",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 36
       },
       "id": 122,
       "panels": [
@@ -4957,7 +5089,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 44
+            "y": 61
           },
           "id": 120,
           "options": {
@@ -5154,7 +5286,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 44
+            "y": 61
           },
           "id": 121,
           "options": {
@@ -5295,7 +5427,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 36
+        "y": 37
       },
       "id": 44,
       "panels": [
@@ -5363,7 +5495,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1631
+            "y": 3454
           },
           "id": 43,
           "interval": "$interval",
@@ -5471,7 +5603,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1631
+            "y": 3454
           },
           "id": 48,
           "interval": "$interval",
@@ -5526,7 +5658,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 37
+        "y": 38
       },
       "id": 84,
       "panels": [
@@ -5594,7 +5726,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1640
+            "y": 3463
           },
           "id": 49,
           "interval": "$interval",
@@ -5693,7 +5825,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1640
+            "y": 3463
           },
           "id": 51,
           "interval": "$interval",
@@ -5738,7 +5870,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 39
       },
       "id": 101,
       "panels": [
@@ -5790,8 +5922,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5807,7 +5938,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 914
+            "y": 2737
           },
           "id": 40,
           "interval": "$interval",
@@ -5900,8 +6031,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5917,7 +6047,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 914
+            "y": 2737
           },
           "id": 42,
           "interval": "$interval",
@@ -5972,7 +6102,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 40
       },
       "id": 41,
       "panels": [
@@ -6040,7 +6170,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 113
+            "y": 1936
           },
           "id": 102,
           "interval": "$interval",
@@ -6149,7 +6279,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 113
+            "y": 1936
           },
           "id": 103,
           "interval": "$interval",
@@ -6204,7 +6334,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 41
       },
       "id": 83,
       "panels": [
@@ -6272,7 +6402,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2424
+            "y": 4247
           },
           "id": 46,
           "interval": "$interval",
@@ -6380,7 +6510,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2424
+            "y": 4247
           },
           "id": 45,
           "interval": "$interval",
@@ -6434,7 +6564,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 42
       },
       "id": 57,
       "panels": [
@@ -6541,7 +6671,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2863
+            "y": 4686
           },
           "id": 56,
           "interval": "$interval",
@@ -6634,7 +6764,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 43
       },
       "id": 111,
       "panels": [
@@ -6765,7 +6895,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 978
+            "y": 2801
           },
           "id": 107,
           "interval": "$interval",
@@ -6960,7 +7090,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 978
+            "y": 2801
           },
           "id": 112,
           "interval": "$interval",
@@ -7119,7 +7249,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 986
+            "y": 2809
           },
           "id": 108,
           "interval": "$interval",
@@ -7347,7 +7477,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 986
+            "y": 2809
           },
           "id": 113,
           "interval": "$interval",
@@ -7502,7 +7632,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 994
+            "y": 2817
           },
           "id": 109,
           "interval": "$interval",
@@ -7730,7 +7860,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 994
+            "y": 2817
           },
           "id": 115,
           "interval": "$interval",
@@ -7886,7 +8016,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1002
+            "y": 2825
           },
           "id": 110,
           "interval": "$interval",
@@ -8110,7 +8240,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1002
+            "y": 2825
           },
           "id": 114,
           "interval": "$interval",

--- a/grafana/source/job.json
+++ b/grafana/source/job.json
@@ -2023,7 +2023,7 @@
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 82
+            "y": 30
           },
           "id": 27,
           "interval": "$interval",
@@ -2133,7 +2133,7 @@
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 82
+            "y": 30
           },
           "id": 87,
           "interval": "$interval",
@@ -2284,7 +2284,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 93
+            "y": 273
           },
           "id": 90,
           "interval": "$interval",
@@ -2367,7 +2367,7 @@
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 1086
+            "y": 2909
           },
           "id": 88,
           "interval": "$interval",
@@ -2477,7 +2477,7 @@
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 1086
+            "y": 2909
           },
           "id": 89,
           "interval": "$interval",
@@ -2627,7 +2627,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1113
+            "y": 2936
           },
           "id": 91,
           "interval": "$interval",
@@ -2702,7 +2702,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "#EAB839",
@@ -2722,7 +2723,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 1122
+            "y": 1068
           },
           "id": 28,
           "interval": "$interval",
@@ -2741,7 +2742,7 @@
             "showThresholdMarkers": true,
             "sizing": "auto"
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -2784,7 +2785,7 @@
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 1122
+            "y": 1068
           },
           "id": 86,
           "interval": "$interval",
@@ -2840,7 +2841,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -2877,7 +2878,8 @@
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "#EAB839",
@@ -2897,7 +2899,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 1810
+            "y": 1076
           },
           "id": 29,
           "interval": "$interval",
@@ -2916,7 +2918,7 @@
             "showThresholdMarkers": true,
             "sizing": "auto"
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -2959,7 +2961,7 @@
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 1810
+            "y": 1076
           },
           "id": 31,
           "interval": "$interval",
@@ -3015,7 +3017,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -3084,7 +3086,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3100,7 +3103,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1818
+            "y": 1084
           },
           "id": 24,
           "interval": "$interval",
@@ -3112,12 +3115,13 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.3.0-76537",
+          "pluginVersion": "11.5.2",
           "targets": [
             {
               "datasource": {
@@ -3321,7 +3325,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 1123
+            "y": 2946
           },
           "id": 52,
           "interval": "$interval",
@@ -3523,7 +3527,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 1188
+            "y": 3011
           },
           "id": 97,
           "interval": "$interval",
@@ -3759,7 +3763,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 1188
+            "y": 3011
           },
           "id": 98,
           "interval": "$interval",
@@ -3938,7 +3942,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 1197
+            "y": 3020
           },
           "id": 95,
           "interval": "$interval",
@@ -4161,7 +4165,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 1467
+            "y": 3290
           },
           "id": 54,
           "interval": "$interval",
@@ -4365,7 +4369,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 1467
+            "y": 3290
           },
           "id": 99,
           "interval": "$interval",
@@ -4528,7 +4532,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 1476
+            "y": 3299
           },
           "id": 100,
           "interval": "$interval",
@@ -4689,7 +4693,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4705,7 +4710,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1125
+            "y": 35
           },
           "id": 33,
           "interval": "$interval",
@@ -4789,7 +4794,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4805,7 +4811,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1133
+            "y": 83
           },
           "id": 104,
           "interval": "$interval",
@@ -4889,7 +4895,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4905,7 +4912,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1141
+            "y": 91
           },
           "id": 22,
           "interval": "$interval",
@@ -5005,7 +5012,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1149
+            "y": 99
           },
           "id": 25,
           "interval": "$interval",
@@ -5105,7 +5112,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1149
+            "y": 99
           },
           "id": 23,
           "interval": "$interval",
@@ -5142,7 +5149,7 @@
           "type": "timeseries"
         }
       ],
-      "title": "GPU Telemetry: GPU IDs",
+      "title": "GPU Telemetry - GPU IDs",
       "type": "row"
     },
     {
@@ -5152,6 +5159,131 @@
         "w": 24,
         "x": 0,
         "y": 35
+      },
+      "id": 123,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${source}"
+          },
+          "description": "Estimated CU occupancy based on the number of in-flight waves of all processes running in each GPU. In-flight waves are translated into number of occupied compute units based on the maximum number of waves per CU. This estimate doesn't account for how waves are distributed, and is not always a good measure of performance.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 36
+          },
+          "id": 125,
+          "interval": "$interval",
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "maxHeight": 600,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${source}"
+              },
+              "editorMode": "code",
+              "expr": "(rocm_compute_unit_occupancy * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"}) * 100 / (rocm_num_compute_units * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
+              "instant": false,
+              "legendFormat": "{{instance}}, {{card}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GPU CU Occupancy (%)",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "([^,:]+)(?:[:].*)?, (.+)",
+                "renamePattern": "GPU: $1/$2"
+              }
+            }
+          ],
+          "type": "timeseries"
+        }
+      ],
+      "title": "GPU Compute Unit Occupancy - GPUs",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 36
       },
       "id": 122,
       "panels": [
@@ -5221,7 +5353,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 44
+            "y": 61
           },
           "id": 120,
           "options": {
@@ -5418,7 +5550,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 44
+            "y": 61
           },
           "id": 121,
           "options": {
@@ -5559,7 +5691,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 36
+        "y": 37
       },
       "id": 44,
       "panels": [
@@ -5627,7 +5759,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1631
+            "y": 3454
           },
           "id": 43,
           "interval": "$interval",
@@ -5735,7 +5867,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1631
+            "y": 3454
           },
           "id": 48,
           "interval": "$interval",
@@ -5790,7 +5922,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 37
+        "y": 38
       },
       "id": 84,
       "panels": [
@@ -5858,7 +5990,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1640
+            "y": 3463
           },
           "id": 49,
           "interval": "$interval",
@@ -5957,7 +6089,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1640
+            "y": 3463
           },
           "id": 51,
           "interval": "$interval",
@@ -6002,7 +6134,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 39
       },
       "id": 101,
       "panels": [
@@ -6054,8 +6186,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -6071,7 +6202,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 914
+            "y": 2737
           },
           "id": 40,
           "interval": "$interval",
@@ -6164,8 +6295,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -6181,7 +6311,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 914
+            "y": 2737
           },
           "id": 42,
           "interval": "$interval",
@@ -6274,8 +6404,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -6291,7 +6420,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 922
+            "y": 2745
           },
           "id": 105,
           "interval": "$interval",
@@ -6384,8 +6513,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -6401,7 +6529,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 922
+            "y": 2745
           },
           "id": 106,
           "interval": "$interval",
@@ -6456,7 +6584,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 40
       },
       "id": 41,
       "panels": [
@@ -6524,7 +6652,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 113
+            "y": 1936
           },
           "id": 102,
           "interval": "$interval",
@@ -6633,7 +6761,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 113
+            "y": 1936
           },
           "id": 103,
           "interval": "$interval",
@@ -6742,7 +6870,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 951
+            "y": 2774
           },
           "id": 116,
           "interval": "$interval",
@@ -6851,7 +6979,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 951
+            "y": 2774
           },
           "id": 117,
           "interval": "$interval",
@@ -6906,7 +7034,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 41
       },
       "id": 83,
       "panels": [
@@ -6974,7 +7102,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2424
+            "y": 4247
           },
           "id": 46,
           "interval": "$interval",
@@ -7082,7 +7210,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2424
+            "y": 4247
           },
           "id": 45,
           "interval": "$interval",
@@ -7136,7 +7264,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 42
       },
       "id": 57,
       "panels": [
@@ -7243,7 +7371,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2863
+            "y": 4686
           },
           "id": 56,
           "interval": "$interval",
@@ -7336,7 +7464,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 43
       },
       "id": 111,
       "panels": [
@@ -7467,7 +7595,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 978
+            "y": 2801
           },
           "id": 107,
           "interval": "$interval",
@@ -7662,7 +7790,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 978
+            "y": 2801
           },
           "id": 112,
           "interval": "$interval",
@@ -7821,7 +7949,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 986
+            "y": 2809
           },
           "id": 108,
           "interval": "$interval",
@@ -8049,7 +8177,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 986
+            "y": 2809
           },
           "id": 113,
           "interval": "$interval",
@@ -8204,7 +8332,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 994
+            "y": 2817
           },
           "id": 109,
           "interval": "$interval",
@@ -8432,7 +8560,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 994
+            "y": 2817
           },
           "id": 115,
           "interval": "$interval",
@@ -8588,7 +8716,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1002
+            "y": 2825
           },
           "id": 110,
           "interval": "$interval",
@@ -8812,7 +8940,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1002
+            "y": 2825
           },
           "id": 114,
           "interval": "$interval",

--- a/omnistat/collector_smi.py
+++ b/omnistat/collector_smi.py
@@ -387,8 +387,9 @@ class ROCMSMI(Collector):
         if self.__power_cap_monitoring:
             self.registerGPUMetric(self.__prefix + "power_cap_watts", "gauge", "Max power cap of device (W)")
 
-        # If CU occupancy is enabled, measure the number of CUs once when registering metrics.
         if self.__cu_occupancy_monitoring:
+            # Measure the number CUs in each GPU node ID (KFD internal GPU index),
+            # and map it to KFD GPU indices.
             counts = count_compute_units(nodeMapping.values())
             self.__num_compute_units = {i: counts[node] for i, node in nodeMapping.items()}
             self.registerGPUMetric(self.__prefix + "num_compute_units", "gauge", "Number of compute units")

--- a/omnistat/collector_smi.py
+++ b/omnistat/collector_smi.py
@@ -387,8 +387,7 @@ class ROCMSMI(Collector):
         if self.__power_cap_monitoring:
             self.registerGPUMetric(self.__prefix + "power_cap_watts", "gauge", "Max power cap of device (W)")
 
-        # If CU occupancy is enabled, measure the number of CUs once when
-        # registering metrics.
+        # If CU occupancy is enabled, measure the number of CUs once when registering metrics.
         if self.__cu_occupancy_monitoring:
             counts = count_compute_units(nodeMapping.values())
             self.__num_compute_units = {i: counts[node] for i, node in nodeMapping.items()}

--- a/omnistat/collector_smi_v2.py
+++ b/omnistat/collector_smi_v2.py
@@ -295,8 +295,9 @@ class AMDSMI(Collector):
                 self.__prefix + "power_cap_watts", "Max power cap of device (W)", labelnames=["card"]
             )
 
-        # If CU occupancy is enabled, measure the number of CUs once when registering metrics.
         if self.__cu_occupancy_monitoring:
+            # Measure the number CUs in each GPU node ID (KFD internal GPU index),
+            # and map it to KFD GPU indices.
             counts = count_compute_units(nodeMapping.values())
             self.__num_compute_units = {i: counts[node] for i, node in nodeMapping.items()}
             self.__GPUMetrics["num_compute_units"] = Gauge(
@@ -372,11 +373,9 @@ class AMDSMI(Collector):
 
             # CU occupancy
             if self.__cu_occupancy_monitoring:
-                metric = "num_compute_units"
-                self.__GPUMetrics[metric].labels(card=cardId).set(self.__num_compute_units[idx])
+                self.__GPUMetrics["num_compute_units"].labels(card=cardId).set(self.__num_compute_units[idx])
 
-                metric = "compute_unit_occupancy"
                 cu_occupancy = get_occupancy(guid)
-                self.__GPUMetrics[metric].labels(card=cardId).set(cu_occupancy)
+                self.__GPUMetrics["compute_unit_occupancy"].labels(card=cardId).set(cu_occupancy)
 
         return

--- a/omnistat/monitor.py
+++ b/omnistat/monitor.py
@@ -84,7 +84,9 @@ class Monitor:
         self.runtimeConfig["collector_port"] = config["omnistat.collectors"].get("port", 8001)
         self.runtimeConfig["collector_rocm_path"] = config["omnistat.collectors"].get("rocm_path", "/opt/rocm")
         self.runtimeConfig["collector_ras_ecc"] = config["omnistat.collectors"].getboolean("enable_ras_ecc", True)
-        self.runtimeConfig["collector_cu_occupancy"] = config["omnistat.collectors"].getboolean("enable_cu_occupancy", False)
+        self.runtimeConfig["collector_cu_occupancy"] = config["omnistat.collectors"].getboolean(
+            "enable_cu_occupancy", False
+        )
         self.runtimeConfig["collector_power_capping"] = config["omnistat.collectors"].getboolean(
             "enable_power_cap", False
         )

--- a/omnistat/monitor.py
+++ b/omnistat/monitor.py
@@ -84,6 +84,7 @@ class Monitor:
         self.runtimeConfig["collector_port"] = config["omnistat.collectors"].get("port", 8001)
         self.runtimeConfig["collector_rocm_path"] = config["omnistat.collectors"].get("rocm_path", "/opt/rocm")
         self.runtimeConfig["collector_ras_ecc"] = config["omnistat.collectors"].getboolean("enable_ras_ecc", True)
+        self.runtimeConfig["collector_cu_occupancy"] = config["omnistat.collectors"].getboolean("enable_cu_occupancy", False)
         self.runtimeConfig["collector_power_capping"] = config["omnistat.collectors"].getboolean(
             "enable_power_cap", False
         )

--- a/omnistat/utils.py
+++ b/omnistat/utils.py
@@ -186,7 +186,8 @@ def gpu_index_mapping_based_on_bdfs(bdfMapping, expectedNumGPUs):
 
 def count_compute_units(nodes):
     """
-    Count the number of compute units for each one of the given GPU node IDs.
+    Count the number of compute units for each one of the given GPU node IDs
+    (KFD internal GPU indices).
 
     Args:
         nodes (list): list of GPU node IDs to calculate the number of CUs for.


### PR DESCRIPTION
This PR introduces per-GPU CU occupancy metrics. It relies on files generated on for each process by the driver under `/sys/class/kfd/kfd/proc/{PID}/stats_{GUID}/cu_occupancy`.

These `cu_occupancy` files report the number of compute units that are occupied for any given process and GPU. It takes the number of waves in-flight and translates them into a number of compute units based on the maximum number of waves per CU. Reference: https://github.com/ROCm/ROCK-Kernel-Driver/blob/ceb12c04e2b5b53ec0779362831f5ee40c4921e4/drivers/gpu/drm/amd/amdkfd/kfd_process.c#L257-L326

Two additional metrics have been added as part of this PR:
- `rocm_num_compute_units`: Total number of CUs per GPU (static).
- `rocm_compute_unit_occupancy`: CU occupancy per GPU, aggregating CU occupancy from all processes. (It would be easy to keep track of process IDs. This initial version of the PR reports per-GPU occupancy to avoid cardinality issues in system mode.)

With these two metrics, it's possible to provide a high-level occupancy percentage as follows: `rocm_compute_unit_occupancy * 100 /  rocm_num_compute_units`.

**Comparison**

CU occupancy as measured in this PR uses the same source for occupancy values as other tools, but there are some small differences.
- `rocm-smi`. Can be called from the CLI with `rocm-smi --showpids`, or using the `rsmi_compute_process_info_by_pid_get()` function. It's described as "Compute Unit usage in percent". The implementation basically aggregates values from sysfs `cu_occupancy` files and provides a global occupancy value for each process, aggregating all CUs and occupancies in *all GPUs*.
- `amd-smi`. Library functions like `amdsmi_get_gpu_compute_process_info()` and `amdsmi_get_gpu_compute_process_info_by_pid()` are similar to `rocm-smi`.

So any discrepancy between CU occupancy provided by this PR and that reported by `rocm-smi` or `amd-smi` is mainly due to how these tools aggregate all GPUs in a node, while Omnistat intends to provide per-GPU occupancies. In the presence of a single GPU, results are equivalent.

**Example**

The following screenshot shows utilization, occupancy and power during the execution of a simple vector add kernel with increasing block sizes of 32, 64, 128, 256, 512, and 1024.
<img width="712" alt="occupancy" src="https://github.com/user-attachments/assets/dd44e32b-0cb9-4129-b361-0fad7717bbec" />

**Limitations**
CU occupancy is just another tool to help understand performance, but it's not a perfect measure of how well GPU resources are being utilized.
- Higher CU occupancy doesn't always lead to better performance.
- We simply track CU occupancy, but we have no way to identify factors constraining occupancy. It could be lack of waves or something else like the number of registers.

**Tasks**
- [x] Add occupancy metrics to rocm-smi collector.
- [x] Add occupancy metrics to amd-smi collector.
- [x] ~~Split occupancy code into its own collector that can be used independently of rocm-smi/amd-smi.~~ For now occupancy code remains in the SMI collectors, with generic functions in utils. The main reason to keep CU occupancy code in the SMI collectors is to make sure card indexing is the same and we don't need to re-initialize SMI.
- [x] Add dashboard panels for CU occupancy.

Additional items to discuss/review:
- Add more dashboard panels and/or move panels to different section(s).
- Confirm metric names.
- Document CU occupancy and possibly provide some examples to highlight how it can be used. Or merge first as experimental and then add it to official documentation later?
- Validate indexing in scenarios with pass-through.