### PR TITLE
Fix variable in amdsmi collector

### DIFF
--- a/omnistat/collector_smi_v2.py
+++ b/omnistat/collector_smi_v2.py
@@ -268,7 +268,7 @@ class AMDSMI(Collector):
             else:
                 logging.info("--> Using mapping %s -> %s " % (desired_metric, found))
                 self.__GPUMetrics[self.__prefix + desired_metric] = Gauge(
-                    self.__prefix + desired_metric, f"{metric}", labelnames=["card", "source"]
+                    self.__prefix + desired_metric, f"{desired_metric}", labelnames=["card", "source"]
                 )
 
         # Register remaining metrics of interest available from get_gpu_metrics()


### PR DESCRIPTION
Simple fix for the amdsmi collector, which is currently failing because it's attempting to use a variable that hasn't been set.

```
[2025-06-27 14:18:03 -0500] [3777380] [INFO] Starting gunicorn 21.2.0                                                                                           [2025-06-27 14:18:03 -0500] [3777380] [INFO] Listening at: http://0.0.0.0:8088 (3777380)
[2025-06-27 14:18:03 -0500] [3777380] [INFO] Using worker: sync
[2025-06-27 14:18:03 -0500] [3777383] [INFO] Booting worker with pid: 3777383
[2025-06-27 14:18:03 -0500] [3777383] [ERROR] Exception in worker process
Traceback (most recent call last):
  File "gunicorn/arbiter.py", line 608, in spawn_worker
    self.cfg.post_fork(self, worker)
  File "omnistat/node_monitoring.py", line 95, in post_fork
    monitor.initMetrics()
  File "omnistat/monitor.py", line 182, in initMetrics
    collector.registerMetrics()
  File "omnistat/collector_smi_v2.py", line 271, in registerMetrics
    self.__prefix + desired_metric, f"{metric}", labelnames=["card", "source"]
UnboundLocalError: local variable 'metric' referenced before assignment
[2025-06-27 14:18:03 -0500] [3777383] [INFO] Worker exiting (pid: 3777383)
[2025-06-27 14:18:03 -0500] [3777380] [ERROR] Worker (pid:3777383) exited with code 3
[2025-06-27 14:18:03 -0500] [3777380] [ERROR] Shutting down: Master
[2025-06-27 14:18:03 -0500] [3777380] [ERROR] Reason: Worker failed to boot.
```