### PR TITLE
Add new (optional) data collector to pull in power management counters 

### DIFF
--- a/docs/installation/user-mode.md
+++ b/docs/installation/user-mode.md
@@ -260,10 +260,10 @@ The export functionality will generate one or more CSV files, depending on
 which collectors are enabled in the Omnistat configuration, as outlined in the
 following table.
 
-| File                   | Collector               | Description                    |
-| :--------------------- | :---------------------: | :----------------------------- |
-| `omnistat-rocm.csv`    | `rocm_smi` or `amd_smi` | GPU utilization and telemetry. |
-| `omnistat-network.csv` | `network`               | Network bandwidth.             |
+| File                    | Collector               | Description                          |
+| :---------------------- | :---------------------: | :----------------------------------- |
+| `omnistat-rocm.gpu.csv` | `rocm_smi` or `amd_smi` | GPU-level utilization and telemetry. |
+| `omnistat-network.csv`  | `network`               | Network bandwidth.                   |
 
 Exported data can be easily loaded as a data frame using tools like Pandas for
 further processing.
@@ -274,7 +274,7 @@ further processing.
 
    import pandas
 
-   df = pandas.read_csv("omnistat-rocm.csv", header=[0, 1, 2], index_col=0)
+   df = pandas.read_csv("omnistat-rocm.gpu.csv", header=[0, 1, 2], index_col=0)
 
    # Select a single metric
    df["rocm_utilization_percentage"]
@@ -297,7 +297,7 @@ further processing.
    import pandas
    import matplotlib.pyplot as plt
 
-   df = pandas.read_csv("omnistat-rocm.csv", header=[0, 1, 2], index_col=0)
+   df = pandas.read_csv("omnistat-rocm.gpu.csv", header=[0, 1, 2], index_col=0)
    df.index = pandas.to_datetime(df.index)
 
    # Create a new dataframe with node averages

--- a/omnistat/collector_pm_counters.py
+++ b/omnistat/collector_pm_counters.py
@@ -64,6 +64,10 @@ class PM_COUNTERS(Collector):
         definedMetrics = {}
 
         logging.info("collector_pm_counters: scanning files in %s" % self.__pm_counter_dir)
+        if os.path.isdir(self.__pm_counter_dir) is False:
+            logging.warning("--> PM counter directory %s does not exist" % self.__pm_counter_dir)
+            logging.warning("--> skipping PM counter data collection")
+            return
         for file in Path(self.__pm_counter_dir).iterdir():
             logging.debug("Examining PM counter filename: %s" % file)
             if any(name in str(file) for name in self.__skipnames):

--- a/omnistat/collector_pm_counters.py
+++ b/omnistat/collector_pm_counters.py
@@ -1,0 +1,121 @@
+# -------------------------------------------------------------------------------
+# MIT License
+#
+# Copyright (c) 2023 - 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# -------------------------------------------------------------------------------
+
+"""PM counter monitoring
+
+Scans telmetry in /sys/cray/pm_counters for compute node power-related data.
+"""
+
+import json
+import logging
+import os
+import platform
+import re
+import sys
+from pathlib import Path
+
+from prometheus_client import Gauge
+
+import omnistat.utils as utils
+from omnistat.collector_base import Collector
+
+
+class PM_COUNTERS(Collector):
+    def __init__(self, annotations=False, jobDetection=None):
+        logging.debug("Initializing pm_counter data collector")
+
+        self.__prefix = "omnistat_pmcounter_"
+        self.__pm_counter_dir = "/sys/cray/pm_counters"
+        self.__skipnames = ["power_cap","startup","freshness","raw_scan_hz","version","generation","_temp"]
+        self.__gpumetrics = ["accel"]
+        # metric data structure for host oriented metrics
+        # --> format: (gauge metric, filepath of source data)
+        self.__pm_files_gpu = []
+        # metric data structure for gpu oriented
+        # --> format: (gauge metric, filepath of source data, gpuindex)
+        self.__pm_files_host = []
+
+
+    def registerMetrics(self):
+        """Register metrics of interest"""
+
+        definedMetrics = {}
+
+        logging.info("collector_pm_counters: scanning files in %s" % self.__pm_counter_dir)
+        for file in Path(self.__pm_counter_dir).iterdir():
+            logging.debug("Examining PM counter filename: %s" % file)
+            if any(name in str(file) for name in self.__skipnames):
+                logging.debug("--> Skipping PM file: %s" % file)
+            else:
+                for gpumetric in self.__gpumetrics:
+                    pattern = fr"^({gpumetric})(\d+)(_.*)$"
+                    match = re.match(pattern,file.name)
+                    if match:
+                        metric_name = match.group(1) + match.group(3)
+                        gpu_id = int(match.group(2))
+                        logging.info("--> Registering GPU-level PM counter metric: %s (card=%i)" % (metric_name, gpu_id))
+                        if metric_name in definedMetrics:
+                            gauge = definedMetrics[metric_name]
+                        else:
+                            gauge = Gauge(self.__prefix + metric_name, metric_name, labelnames=["card"])
+                            definedMetrics[metric_name] = gauge
+                        metric_entry = (gauge,str(file),gpu_id)                            
+                        self.__pm_files_gpu.append(metric_entry)
+                    else:
+                        metric_name = file.name
+                        logging.info("--> Registering host-level PM counter metric: %s" % metric_name)
+                        gauge = Gauge(self.__prefix + metric_name, metric_name)
+                        metric_entry = (gauge, str(file))
+                        self.__pm_files_host.append(metric_entry)
+
+    def updateMetrics(self):
+        """Update registered metrics of interest"""
+
+        # Host-level data...
+        for entry in self.__pm_files_host:
+            gaugeMetric = entry[0]
+            filePath = entry[1]
+            try:
+                with open(filePath,"r") as f:
+                    data = f.readline().strip().split()
+                    gaugeMetric.set(float(data[0]))
+            except:
+                pass
+
+        # GPU data...
+        for entry in self.__pm_files_gpu:
+            gaugeMetric = entry[0]
+            filePath = entry[1]
+            gpuIndex = entry[2]
+            try:
+                with open(filePath,"r") as f:
+                    data = f.readline().strip().split()
+                    print(data)
+                    gaugeMetric.labels(card=gpuIndex).set(data[0])
+
+            except:
+                pass            
+
+        return
+

--- a/omnistat/collector_pm_counters.py
+++ b/omnistat/collector_pm_counters.py
@@ -46,7 +46,7 @@ class PM_COUNTERS(Collector):
     def __init__(self, annotations=False, jobDetection=None):
         logging.debug("Initializing pm_counter data collector")
 
-        self.__prefix = "omnistat_vendor_counters_"
+        self.__prefix = "omnistat_vendor_"
         # currently just supporting a single vendor
         self.__pm_counter_dir = "/sys/cray/pm_counters"
         self.__vendor = "cray"

--- a/omnistat/collector_pm_counters.py
+++ b/omnistat/collector_pm_counters.py
@@ -109,7 +109,7 @@ class PM_COUNTERS(Collector):
                         self.__pm_files_gpu.append(metric_entry)
 
                     else:
-                        metric_name = file.name
+                        metric_name = file.name + f"_{units}"
                         description = f"Node-level {metric_name} ({units_short})"
                         gauge = Gauge(self.__prefix + metric_name, description, labelnames=["vendor"])
                         metric_entry = (gauge, str(file))

--- a/omnistat/collector_pm_counters.py
+++ b/omnistat/collector_pm_counters.py
@@ -74,20 +74,22 @@ class PM_COUNTERS(Collector):
                     if match:
                         metric_name = match.group(1) + match.group(3)
                         gpu_id = int(match.group(2))
-                        logging.info("--> Registering GPU-level PM counter metric: %s (card=%i)" % (metric_name, gpu_id))
                         if metric_name in definedMetrics:
                             gauge = definedMetrics[metric_name]
                         else:
                             gauge = Gauge(self.__prefix + metric_name, metric_name, labelnames=["card"])
                             definedMetrics[metric_name] = gauge
+                            logging.info("--> [Registered] %s (gauge)" % (self.__prefix + metric_name))
+                            
                         metric_entry = (gauge,str(file),gpu_id)                            
                         self.__pm_files_gpu.append(metric_entry)
+
                     else:
                         metric_name = file.name
-                        logging.info("--> Registering host-level PM counter metric: %s" % metric_name)
                         gauge = Gauge(self.__prefix + metric_name, metric_name)
                         metric_entry = (gauge, str(file))
                         self.__pm_files_host.append(metric_entry)
+                        logging.info("--> [registered] %s (gauge)" % self.__prefix + metric_name)                        
 
     def updateMetrics(self):
         """Update registered metrics of interest"""
@@ -111,7 +113,6 @@ class PM_COUNTERS(Collector):
             try:
                 with open(filePath,"r") as f:
                     data = f.readline().strip().split()
-                    print(data)
                     gaugeMetric.labels(card=gpuIndex).set(data[0])
 
             except:

--- a/omnistat/collector_pm_counters.py
+++ b/omnistat/collector_pm_counters.py
@@ -99,7 +99,7 @@ class PM_COUNTERS(Collector):
                             gauge = definedMetrics[metric_name]
                         else:
                             description = f"GPU {match.group(3)} ({units_short})"
-                            gauge = Gauge(self.__prefix + metric_name, description, labelnames=["card","vendor"])
+                            gauge = Gauge(self.__prefix + metric_name, description, labelnames=["card", "vendor"])
                             definedMetrics[metric_name] = gauge
                             logging.info(
                                 "--> [Registered] %s -> %s (gauge)" % (self.__prefix + metric_name, description)
@@ -111,7 +111,7 @@ class PM_COUNTERS(Collector):
                     else:
                         metric_name = file.name
                         description = f"Node-level {metric_name} ({units_short})"
-                        gauge = Gauge(self.__prefix + metric_name, description,labelnames=["vendor"])
+                        gauge = Gauge(self.__prefix + metric_name, description, labelnames=["vendor"])
                         metric_entry = (gauge, str(file))
                         self.__pm_files_host.append(metric_entry)
                         logging.info("--> [registered] %s -> %s (gauge)" % (self.__prefix + metric_name, description))
@@ -138,7 +138,7 @@ class PM_COUNTERS(Collector):
             try:
                 with open(filePath, "r") as f:
                     data = f.readline().strip().split()
-                    gaugeMetric.labels(card=gpuIndex,vendor=self.__vendor).set(data[0])
+                    gaugeMetric.labels(card=gpuIndex, vendor=self.__vendor).set(data[0])
 
             except:
                 pass

--- a/omnistat/collector_rms.py
+++ b/omnistat/collector_rms.py
@@ -81,7 +81,7 @@ class RMSJob(Collector):
             # job step query command
             flags = "-s -w " + hostname + " -h --Format=StepID"
             self.__squeue_steps = [command] + flags.split()
-            logging.debug("sqeueue_exec = %s" % self.__squeue_query)
+            logging.debug("squeue_exec = %s" % self.__squeue_query)
         else:
             logging.error("Unsupported slurm job data collection mode")
 

--- a/omnistat/collector_rms.py
+++ b/omnistat/collector_rms.py
@@ -54,8 +54,11 @@ class RMSJob(Collector):
         self.__rmsJobFile = jobDetection["file"]
         self.__rmsJobStepFile = jobDetection["stepfile"]
         self.__rmsJobFileTimeStamp = 0
+        self.__rmsJobStepFileTimeStamp = 0
         self.__rmsAnnotationsFileTimeStamp = 0
+
         self.__resultsCached = {}
+        self.__resultsStepCached = {}
         self.__annotationsCached = {}
 
         # jobMode
@@ -135,8 +138,16 @@ class RMSJob(Collector):
         elif mode == "file-based":
             # preference is given to job step file if it exists
             if os.path.isfile(self.__rmsJobStepFile):
-                with open(self.__rmsJobStepFile, "r") as file:
-                    results = json.load(file)
+                # only read contents if modify timestamp has been updated
+                modTime = os.path.getmtime(self.__rmsJobStepFile)
+                if modTime > self.__rmsJobStepFileTimeStamp:
+                    with open(self.__rmsJobStepFile, "r") as file:
+                        logging.info("[file-based (step)]: reading %s " % self.__rmsJobStepFile)
+                        self.__rmsJobStepFileTimeStamp = modTime
+                        results = json.load(file)
+                    self.__resultsStepCached = results
+                else:
+                    results = self.__resultsStepCached
             elif os.path.isfile(self.__rmsJobFile):
                 # only read contents if modify timestamp has been updated
                 modTime = os.path.getmtime(self.__rmsJobFile)

--- a/omnistat/monitor.py
+++ b/omnistat/monitor.py
@@ -70,7 +70,7 @@ class Monitor:
         )
         self.runtimeConfig["collector_enable_pm_counters"] = config["omnistat.collectors"].getboolean(
             "enable_pm_counters", False
-        )        
+        )
 
         # verify only one SMI collector is enabled
         if self.runtimeConfig["collector_enable_rocm_smi"] and self.runtimeConfig["collector_enable_amd_smi"]:
@@ -142,11 +142,11 @@ class Monitor:
 
     def initMetrics(self):
 
-        if self.runtimeConfig["collector_enable_pm_counters"]:        
+        if self.runtimeConfig["collector_enable_pm_counters"]:
             from omnistat.collector_pm_counters import PM_COUNTERS
 
             self.__collectors.append(PM_COUNTERS())
-        
+
         if self.runtimeConfig["collector_enable_network"]:
             from omnistat.collector_network import NETWORK
 

--- a/omnistat/monitor.py
+++ b/omnistat/monitor.py
@@ -68,6 +68,9 @@ class Monitor:
         self.runtimeConfig["collector_enable_network"] = config["omnistat.collectors"].getboolean(
             "enable_network", True
         )
+        self.runtimeConfig["collector_enable_pm_counters"] = config["omnistat.collectors"].getboolean(
+            "enable_pm_counters", False
+        )        
 
         # verify only one SMI collector is enabled
         if self.runtimeConfig["collector_enable_rocm_smi"] and self.runtimeConfig["collector_enable_amd_smi"]:
@@ -139,6 +142,11 @@ class Monitor:
 
     def initMetrics(self):
 
+        if self.runtimeConfig["collector_enable_pm_counters"]:        
+            from omnistat.collector_pm_counters import PM_COUNTERS
+
+            self.__collectors.append(PM_COUNTERS())
+        
         if self.runtimeConfig["collector_enable_network"]:
             from omnistat.collector_network import NETWORK
 

--- a/omnistat/query.py
+++ b/omnistat/query.py
@@ -366,6 +366,7 @@ class QueryMetrics:
         # node-level data: cpu energy usage
         times_raw, values_raw, hosts = self.query_time_series_data("omnistat_vendor_cpu_energy_joules")
         node_level_cpu_energy_total = 0.0
+        # sum energy over all nodes assigned to job
         for i in range(len(values_raw)):
             cpu_energy = values_raw[i][-1] - values_raw[i][0]
             node_level_cpu_energy_total += cpu_energy
@@ -383,10 +384,12 @@ class QueryMetrics:
             )
             if values_raw:
                 vendor_ngpus += 1
+                accel_energy = 0
+                # loop over all assigned hosts for current gpu index to accumulate energy
                 for i in range(len(values_raw)):
-                    accel_energy = values_raw[i][-1] - values_raw[i][0]
-                    node_level_accel_energy_total += accel_energy
-                    energy_gpus.append(accel_energy)
+                    accel_energy += values_raw[i][-1] - values_raw[i][0]
+                    node_level_accel_energy_total += values_raw[i][-1] - values_raw[i][0]
+                energy_gpus.append(accel_energy)
                 # convert from J to kwH
                 self.node_level_accel_energy_total_kwh = node_level_accel_energy_total / (1000 * 3600)
 

--- a/omnistat/query.py
+++ b/omnistat/query.py
@@ -1126,6 +1126,21 @@ class QueryMetrics:
                 ["omnistat_rocprofiler"],
                 ["instance", "card", "counter"],
             ),
+            "vendor": (
+                [
+                    "omnistat_vendor_energy_joules",
+                    "omnistat_vendor_memory_energy_joules",
+                    "omnistat_vendor_cpu_energy_joules",
+                    "omnistat_vendor_power_watts",
+                    "omnistat_vendor_memory_power_watts",
+                    "omnistat_vendor_cpu_power_watts",
+                ],
+                ["instance", "vendor"],
+            ),
+            "vendor-gpu": (
+                ["omnistat_vendor_accel_energy_joules", " omnistat_vendor_accel_power_watts"],
+                ["instance", "card", "vendor"],
+            ),
         }
 
         for name, (metrics, labels) in exports.items():

--- a/omnistat/query.py
+++ b/omnistat/query.py
@@ -1130,6 +1130,11 @@ class QueryMetrics:
                 ["instance", "card", "counter"],
             ),
             (
+                "fom",
+                ["omnistat_fom"],
+                ["instance", "name"],
+            ),
+            (
                 "vendor",
                 [
                     "omnistat_vendor_energy_joules",

--- a/omnistat/query.py
+++ b/omnistat/query.py
@@ -1110,23 +1110,27 @@ class QueryMetrics:
     def export(self, export_path):
         export_prefix = "omnistat-"
 
-        # Map files to be generated for different subsets of metrics. Values
-        # are tuples containing 1) a list of metrics, and 2) a list of labels
-        # to be used for hierarchical indexing.
-        exports = {
-            "rocm": (
+        # List files to be generated for different subsets of metrics. Values
+        # are tuples containing 1) file name, 2) a list of metrics, and 3) a
+        # list of labels to be used for hierarchical indexing.
+        exports = [
+            (
+                "rocm",
                 [x["metric"] for x in QueryMetrics.METRICS],
                 ["instance", "card"],
             ),
-            "network": (
+            (
+                "network",
                 ["omnistat_network_rx_bytes", "omnistat_network_tx_bytes"],
                 ["instance", "device_class", "interface"],
             ),
-            "rocprofiler": (
+            (
+                "rocprofiler",
                 ["omnistat_rocprofiler"],
                 ["instance", "card", "counter"],
             ),
-            "vendor": (
+            (
+                "vendor",
                 [
                     "omnistat_vendor_energy_joules",
                     "omnistat_vendor_memory_energy_joules",
@@ -1137,14 +1141,16 @@ class QueryMetrics:
                 ],
                 ["instance", "vendor"],
             ),
-            "vendor-gpu": (
+            (
+                "vendor",
                 ["omnistat_vendor_accel_energy_joules", " omnistat_vendor_accel_power_watts"],
                 ["instance", "card", "vendor"],
             ),
-        }
+        ]
 
-        for name, (metrics, labels) in exports.items():
-            export_file = f"{export_path}/{export_prefix}{name}.csv"
+        for name, metrics, labels in exports:
+            extension = ".gpu.csv" if "card" in labels else ".csv"
+            export_file = f"{export_path}/{export_prefix}{name}{extension}"
             self.export_metrics(export_file, metrics, labels)
 
 

--- a/omnistat/query.py
+++ b/omnistat/query.py
@@ -348,7 +348,7 @@ class QueryMetrics:
 
         node_level_energy_total = 0.0
         for i in range(len(values_raw)):
-            node_energy = values_raw[i][-1] - values_raw[i][0]            
+            node_energy = values_raw[i][-1] - values_raw[i][0]
             node_level_energy_total += node_energy
         # convert from J to kwH
         self.node_level_energy_total_kwh = node_level_energy_total / (1000 * 3600)
@@ -358,7 +358,7 @@ class QueryMetrics:
         if values_raw:
             node_level_memory_energy_total = 0.0
             for i in range(len(values_raw)):
-                memory_energy = values_raw[i][-1] - values_raw[i][0]            
+                memory_energy = values_raw[i][-1] - values_raw[i][0]
                 node_level_memory_energy_total += memory_energy
         # convert from J to kwH
         self.node_level_memory_energy_total_kwh = node_level_memory_energy_total / (1000 * 3600)
@@ -367,22 +367,23 @@ class QueryMetrics:
         times_raw, values_raw, hosts = self.query_time_series_data("omnistat_vendor_cpu_energy_joules")
         node_level_cpu_energy_total = 0.0
         for i in range(len(values_raw)):
-            cpu_energy = values_raw[i][-1] - values_raw[i][0]            
+            cpu_energy = values_raw[i][-1] - values_raw[i][0]
             node_level_cpu_energy_total += cpu_energy
         # convert from J to kwH
         self.node_level_cpu_energy_total_kwh = node_level_cpu_energy_total / (1000 * 3600)
 
         # node-level data: accelerator energy usage
-        node_level_accel_energy_total = 0.0        
-        for gpu in range(self.numGPUs):        
-            times_raw, values_raw, hosts = self.query_time_series_data(f'omnistat_vendor_accel_energy_joules{{card="{gpu}"}}')
+        node_level_accel_energy_total = 0.0
+        for gpu in range(self.numGPUs):
+            times_raw, values_raw, hosts = self.query_time_series_data(
+                f'omnistat_vendor_accel_energy_joules{{card="{gpu}"}}'
+            )
             if values_raw:
                 for i in range(len(values_raw)):
-                    accel_energy = values_raw[i][-1] - values_raw[i][0]            
+                    accel_energy = values_raw[i][-1] - values_raw[i][0]
                     node_level_accel_energy_total += accel_energy
                 # convert from J to kwH
                 self.node_level_accel_energy_total_kwh = node_level_accel_energy_total / (1000 * 3600)
-
 
         return
 
@@ -515,13 +516,13 @@ class QueryMetrics:
             if "title_short" in entry:
                 # print("%16s |" % entry['title_short'],end='')
                 print(" %s |" % entry["title_short"].center(16), end="")
-        print(" Energy (kWh) |",end="")
+        print(" Energy (kWh) |", end="")
         print("")
         print("    %6s |" % "GPU #", end="")
         for entry in QueryMetrics.METRICS:
             if "title_short" in entry:
                 print(" %8s%8s |" % ("Max".center(6), "Mean".center(6)), end="")
-        print("    Total     |",end="")
+        print("    Total     |", end="")
         print("")
         print("    " + "-" * 99)
 
@@ -536,19 +537,34 @@ class QueryMetrics:
                     end="",
                 )
             # add gpu-energy
-            print( "   %6.2e   |" % np.sum(self.energyStats_kwh[card]),end="")
+            print("   %6.2e   |" % np.sum(self.energyStats_kwh[card]), end="")
             print("")
 
         if self.vendorData:
             print("")
             print("Vendor Energy data:")
-            print("  " + "-" * 65)            
-            print("  Approximate Total Memory Energy Consumed = %.2e kWh (%5.2f %%)" % (self.node_level_memory_energy_total_kwh,
-                                                                                       100.0*self.node_level_memory_energy_total_kwh/self.node_level_energy_total_kwh))
-            print("  Approximate Total CPU    Energy Consumed = %.2e kWh (%5.2f %%)" % (self.node_level_cpu_energy_total_kwh,
-                                                                                       100.0*self.node_level_cpu_energy_total_kwh / self.node_level_energy_total_kwh))
-            print("  Approximate Total Accel  Energy Consumed = %.2e kWh (%5.2f %%)" % (self.node_level_accel_energy_total_kwh,
-                                                                                       100.0*self.node_level_accel_energy_total_kwh / self.node_level_energy_total_kwh))
+            print("  " + "-" * 65)
+            print(
+                "  Approximate Total Memory Energy Consumed = %.2e kWh (%5.2f %%)"
+                % (
+                    self.node_level_memory_energy_total_kwh,
+                    100.0 * self.node_level_memory_energy_total_kwh / self.node_level_energy_total_kwh,
+                )
+            )
+            print(
+                "  Approximate Total CPU    Energy Consumed = %.2e kWh (%5.2f %%)"
+                % (
+                    self.node_level_cpu_energy_total_kwh,
+                    100.0 * self.node_level_cpu_energy_total_kwh / self.node_level_energy_total_kwh,
+                )
+            )
+            print(
+                "  Approximate Total Accel  Energy Consumed = %.2e kWh (%5.2f %%)"
+                % (
+                    self.node_level_accel_energy_total_kwh,
+                    100.0 * self.node_level_accel_energy_total_kwh / self.node_level_energy_total_kwh,
+                )
+            )
             print("  " + "-" * 65)
             print("  Approximate Total Node Energy Consumed   = %.2e kWh" % self.node_level_energy_total_kwh)
             print("")

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -74,9 +74,11 @@ class TestQuery:
         table = [line for line in report.splitlines() if re.match(pattern, line)]
         report_values = {}
         for row in table:
-            row = row.strip().split("|")
+            row = row.strip().rstrip("|").split("|")
             gpu_id = int(row[0].strip())
-            values = [v for metric in row[1:] for v in metric.split()]
+            # Exclude first and last element in the table (GPU ID and Energy)
+            # from values to validate.
+            values = [v for metric in row[1:-1] for v in metric.split()]
             report_values[gpu_id] = values
 
         assert len(report_values) == len(gpu_values), "Unexpected number of GPUs in the report"


### PR DESCRIPTION
This data collector enables vendor-provided metrics based on files populated in `/sys/cray/pm_counters` on HPE Cray supercomputing environments.  These include node-level and individual accelerator (GPU) telemetry values. Example omnistat counter examples highlighted below:

```
omnistat_vendor_energy_joules{vendor="cray"} 2.178501771e+09
omnistat_vendor_accel_energy_joules{card="0",vendor="cray"} 4.79512261e+08
omnistat_vendor_accel_energy_joules{card="1",vendor="cray"} 4.86017852e+08
omnistat_vendor_accel_energy_joules{card="2",vendor="cray"} 4.84580288e+08
omnistat_vendor_accel_energy_joules{card="3",vendor="cray"} 4.74312657e+08
omnistat_vendor_accel_power_watts{card="3",vendor="cray"} 104.0
omnistat_vendor_accel_power_watts{card="0",vendor="cray"} 103.0
omnistat_vendor_accel_power_watts{card="1",vendor="cray"} 106.0
omnistat_vendor_accel_power_watts{card="2",vendor="cray"} 103.0
omnistat_vendor_power_watts{vendor="cray"} 451.0
omnistat_vendor_memory_energy_joules{vendor="cray"} 2.93871653e+08
omnistat_vendor_cpu_energy_joules{vendor="cray"} 2.08285642e+08
omnistat_vendor_memory_power_watts{vendor="cray"} 64.0
omnistat_vendor_cpu_power_watts{vendor="cray"} 33.0
```