### PR TITLE
Simplify trace library finalization/flushing and add integration tests

### DIFF
--- a/.github/workflows/test-gpus.yml
+++ b/.github/workflows/test-gpus.yml
@@ -37,20 +37,20 @@ jobs:
           pip install -r requirements.txt
           pip install -r test/requirements.txt
 
-      - name: Build kernel trace library
+      - name: Build kernel trace library and test workloads
         run: |
+          module load rocm/7.2.0
           cmake -B build -S rocprofiler-sdk -DBUILD_KERNEL_TRACE_LIB=ON
           cmake --build build
-
-      - name: Build test workloads
-        run: make -C test/workloads
+          make -C test/workloads OFFLOAD_ARCH="gfx90a gfx942"
 
       - name: Collector tests
         run: |
           source omnistat_venv/bin/activate
           srun -N 1 -J omnistat -p $CI_QUEUE -t 00:10:00 \
-            env ROCP_TOOL_LIBRARIES=$PWD/build/libomnistat_trace.so \
-            pytest -v --junitxml=results.xml test/test_collectors.py test/test_endpoint_collectors.py
+            bash -lc "module load rocm/7.2.0 && \
+            ROCP_TOOL_LIBRARIES=$PWD/build/libomnistat_trace.so \
+            pytest -v --junitxml=results.xml test/test_collectors.py test/test_endpoint_collectors.py"
 
 ##       - name: Test Report
 ##         uses: dorny/test-reporter@v2

--- a/.github/workflows/test-gpus.yml
+++ b/.github/workflows/test-gpus.yml
@@ -6,10 +6,13 @@ on:
     - cron: "0 */6 * * *"    # every 6 hours
 
   pull_request:
-    branches: [ main, dev ]      
+    branches: [ main, dev ]
 
 jobs:
   gpu-collectors:
+    defaults:
+      run:
+        shell: bash --login {0}
     runs-on: [self-hosted, instinct]
     strategy:
       matrix:
@@ -37,32 +40,33 @@ jobs:
           pip install -r requirements.txt
           pip install -r test/requirements.txt
 
-      - name: Build kernel trace library and test workloads
+      - name: Build kernel trace library
         run: |
-          module load rocm/7.2.0
           cmake -B build -S rocprofiler-sdk -DBUILD_KERNEL_TRACE_LIB=ON
           cmake --build build
-          make -C test/workloads OFFLOAD_ARCH="gfx90a gfx942"
+
+      - name: Build test workloads
+        run: make -C test/workloads OFFLOAD_ARCH="gfx90a gfx942"
 
       - name: Collector tests
+        env:
+          ROCP_TOOL_LIBRARIES: ${{ github.workspace }}/build/libomnistat_trace.so
         run: |
           source omnistat_venv/bin/activate
           srun -N 1 -J omnistat -p $CI_QUEUE -t 00:10:00 \
-            bash -lc "module load rocm/7.2.0 && \
-            ROCP_TOOL_LIBRARIES=$PWD/build/libomnistat_trace.so \
-            pytest -v --junitxml=results.xml test/test_collectors.py test/test_endpoint_collectors.py"
+            pytest -v --junitxml=results.xml test/test_collectors.py test/test_endpoint_collectors.py
 
 ##       - name: Test Report
 ##         uses: dorny/test-reporter@v2
 ##         if: ${{ !cancelled() }}
 ##         with:
 ##           name: GPU Collectors
-##           reporter: jest-junit 
+##           reporter: jest-junit
 ##           path: results.xml
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v5
-        if: ${{ !cancelled() }}	
+        if: ${{ !cancelled() }}
         with:
           include_passed: 'true'
           report_paths: 'results.xml'

--- a/.github/workflows/test-gpus.yml
+++ b/.github/workflows/test-gpus.yml
@@ -37,10 +37,20 @@ jobs:
           pip install -r requirements.txt
           pip install -r test/requirements.txt
 
+      - name: Build kernel trace library
+        run: |
+          cmake -B build -S rocprofiler-sdk -DBUILD_KERNEL_TRACE_LIB=ON
+          cmake --build build
+
+      - name: Build test workloads
+        run: make -C test/workloads
+
       - name: Collector tests
         run: |
           source omnistat_venv/bin/activate
-          srun -N 1 -J omnistat -p $CI_QUEUE -t 00:10:00 pytest -v --junitxml=results.xml test/test_collectors.py
+          srun -N 1 -J omnistat -p $CI_QUEUE -t 00:10:00 \
+            env ROCP_TOOL_LIBRARIES=$PWD/build/libomnistat_trace.so \
+            pytest -v --junitxml=results.xml test/test_collectors.py test/test_endpoint_collectors.py
 
 ##       - name: Test Report
 ##         uses: dorny/test-reporter@v2

--- a/.github/workflows/test-gpus.yml
+++ b/.github/workflows/test-gpus.yml
@@ -39,6 +39,10 @@ jobs:
           pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r test/requirements.txt
+          pip install nanobind
+          cmake -S rocprofiler-sdk/ -B build/
+          cmake --build build/
+          cmake --install build/ --prefix .
 
       - name: Build kernel trace library
         run: |
@@ -51,6 +55,8 @@ jobs:
       - name: Collector tests
         env:
           ROCP_TOOL_LIBRARIES: ${{ github.workspace }}/build/libomnistat_trace.so
+          # Workaround to make sure counters work when tracing is also enabled
+          HSA_TOOLS_ROCPROFILER_V1_TOOLS: 1
         run: |
           source omnistat_venv/bin/activate
           srun -N 1 -J omnistat -p $CI_QUEUE -t 00:10:00 \

--- a/.github/workflows/test-mi325.yml
+++ b/.github/workflows/test-mi325.yml
@@ -62,8 +62,7 @@ jobs:
           python3 -m venv --system-site-packages omnistat_venv
           source omnistat_venv/bin/activate
           pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r test/requirements.txt
+          BUILD_ROCPROFILER_SDK_EXTENSION=1 pip install .[query]
           
       - name: Build kernel trace library
         run: |

--- a/.github/workflows/test-mi325.yml
+++ b/.github/workflows/test-mi325.yml
@@ -65,11 +65,21 @@ jobs:
           pip install -r requirements.txt
           pip install -r test/requirements.txt
           
+      - name: Build kernel trace library
+        run: |
+          cmake -B build -S rocprofiler-sdk -DBUILD_KERNEL_TRACE_LIB=ON
+          cmake --build build
+
+      - name: Build test workloads
+        run: make -C test/workloads
+
       - name: Collector tests
+        env:
+          ROCP_TOOL_LIBRARIES: ${{ github.workspace }}/build/libomnistat_trace.so
         run: |
           source omnistat_venv/bin/activate
           su - ubuntu -c "sleep 300 &"
-          pytest -s -v --junitxml=results.xml test/test_collectors.py
+          pytest -s -v --junitxml=results.xml test/test_collectors.py test/test_endpoint_collectors.py
 
 ##       - name: Test Report
 ##         uses: dorny/test-reporter@v2

--- a/.github/workflows/test-mi325.yml
+++ b/.github/workflows/test-mi325.yml
@@ -62,7 +62,12 @@ jobs:
           python3 -m venv --system-site-packages omnistat_venv
           source omnistat_venv/bin/activate
           pip install --upgrade pip
-          BUILD_ROCPROFILER_SDK_EXTENSION=1 pip install .[query]
+          pip install -r requirements.txt
+          pip install -r test/requirements.txt
+          pip install nanobind
+          cmake -S rocprofiler-sdk/ -B build/
+          cmake --build build/
+          cmake --install build/ --prefix .
           
       - name: Build kernel trace library
         run: |
@@ -75,6 +80,8 @@ jobs:
       - name: Collector tests
         env:
           ROCP_TOOL_LIBRARIES: ${{ github.workspace }}/build/libomnistat_trace.so
+          # Workaround to make sure counters work when tracing is also enabled
+          HSA_TOOLS_ROCPROFILER_V1_TOOLS: 1
         run: |
           source omnistat_venv/bin/activate
           su - ubuntu -c "sleep 300 &"

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ omnistat.egg-info/
 omnistat/*.so
 test/slurm-job-user.sh
 grafana/json-models/user/
+test/workloads/launch_kernels

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ omnistat/*.so
 test/slurm-job-user.sh
 grafana/json-models/user/
 test/workloads/launch_kernels
+test/workloads/vector_add

--- a/rocprofiler-sdk/kernel_tracer.cpp
+++ b/rocprofiler-sdk/kernel_tracer.cpp
@@ -61,24 +61,12 @@ void code_object_callback(rocprofiler_callback_tracing_record_t record,
     auto* tracer = static_cast<KernelTracer*>(tool_data);
 
     if (record.kind == ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT &&
-        record.operation == ROCPROFILER_CODE_OBJECT_LOAD) {
-        if (record.phase == ROCPROFILER_CALLBACK_PHASE_UNLOAD) {
-            // Never reached when using the tool with the ROCP_TOOL_LIBRARIES
-            // environment variable, hence the need to flush on kernel unload.
-            auto flush_status = rocprofiler_flush_buffer(tracer->buffer);
-            if (flush_status != ROCPROFILER_STATUS_ERROR_BUFFER_BUSY)
-                ROCPROFILER_CALL(flush_status, "flush buffer");
-        }
-    } else if (record.kind == ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT &&
                record.operation == ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER) {
         auto* data =
             static_cast<rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t*>(
                 record.payload);
         if (record.phase == ROCPROFILER_CALLBACK_PHASE_LOAD) {
             tracer->kernels.emplace(data->kernel_id, demangle(data->kernel_name));
-        } else if (record.phase == ROCPROFILER_CALLBACK_PHASE_UNLOAD) {
-            ROCPROFILER_CALL(rocprofiler_flush_buffer(tracer->buffer), "flush buffer");
-            tracer->kernels.erase(data->kernel_id);
         }
     }
 }
@@ -89,12 +77,8 @@ void full_buffer_callback(rocprofiler_context_id_t context [[maybe_unused]],
                           void* tool_data, uint64_t drop_count [[maybe_unused]]) {
     auto* tracer = static_cast<KernelTracer*>(tool_data);
 
-    if (num_headers == 0) {
-        throw std::runtime_error{
-            "rocprofiler invoked a buffer callback with no headers. this should never happen"};
-    } else if (headers == nullptr) {
-        throw std::runtime_error{"rocprofiler invoked a buffer callback with a null pointer to the "
-                                 "array of headers. this should never happen"};
+    if (num_headers == 0 || headers == nullptr) {
+        return;
     }
 
     // Estimate bytes per record to reserve memory upfront. Likely
@@ -107,9 +91,9 @@ void full_buffer_callback(rocprofiler_context_id_t context [[maybe_unused]],
     // Start JSON array
     data.push_back('[');
 
+    size_t num_records = 0;
     for (size_t i = 0; i < num_headers; ++i) {
         auto* header = headers[i];
-
         if (header->category == ROCPROFILER_BUFFER_CATEGORY_TRACING &&
             header->kind == ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH) {
             auto* record =
@@ -120,17 +104,18 @@ void full_buffer_callback(rocprofiler_context_id_t context [[maybe_unused]],
                            tracer->agents.at(record->dispatch_info.agent_id.handle),
                            tracer->kernels.at(record->dispatch_info.kernel_id),
                            record->start_timestamp, record->end_timestamp);
-        } else {
-            throw std::runtime_error{
-                fmt::format("unexpected rocprofiler_record_header_t category + kind: ({} + {})",
-                            header->category, header->kind)};
+            ++num_records;
         }
+    }
+
+    if (num_records == 0) {
+        return;
     }
 
     // Replace trailing comma with closing bracket
     data.back() = ']';
 
-    if (!tracer->flush(data, num_headers)) {
+    if (!tracer->flush(data, num_records)) {
         std::cerr << "Omnistat: failed to post kernel trace data" << std::endl;
     }
 }
@@ -203,6 +188,13 @@ int KernelTracer::initialize() {
 }
 
 KernelTracer::~KernelTracer() {
+    // Flush -> stop -> flush, mirroring rocprofv3's finalization sequence.
+    // Stopping the context prevents new records from being emplaced into the
+    // buffer; the second flush drains anything that arrived before the stop.
+    rocprofiler_flush_buffer(buffer);
+    rocprofiler_stop_context(context_);
+    rocprofiler_flush_buffer(buffer);
+
     {
         std::lock_guard<std::mutex> lock(periodic_mutex_);
         stop_requested_.store(true);

--- a/rocprofiler-sdk/kernel_tracer.cpp
+++ b/rocprofiler-sdk/kernel_tracer.cpp
@@ -25,10 +25,17 @@
 #include "kernel_tracer.hpp"
 #include "common.hpp"
 
+#include <rocprofiler-sdk/version.h>
+
+#ifndef ROCPROFILER_SDK_VERSION
+#define ROCPROFILER_SDK_VERSION ROCPROFILER_VERSION
+#endif
+
 #include <chrono>
 #include <cxxabi.h>
 #include <iterator>
 #include <memory>
+#include <stdexcept>
 #include <thread>
 #include <unistd.h>
 
@@ -61,7 +68,7 @@ void code_object_callback(rocprofiler_callback_tracing_record_t record,
     auto* tracer = static_cast<KernelTracer*>(tool_data);
 
     if (record.kind == ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT &&
-               record.operation == ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER) {
+        record.operation == ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER) {
         auto* data =
             static_cast<rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t*>(
                 record.payload);
@@ -295,8 +302,13 @@ void KernelTracer::record_flush_stats(size_t num_headers, bool failed) {
 // ------------------------------------------------------------------------------------------------
 
 int tool_init(rocprofiler_client_finalize_t fini_func [[maybe_unused]], void* tool_data) {
-    auto* tracer = static_cast<omnistat::KernelTracer*>(tool_data);
-    return tracer->initialize();
+    try {
+        auto* tracer = static_cast<omnistat::KernelTracer*>(tool_data);
+        return tracer->initialize();
+    } catch (const std::exception& e) {
+        std::cerr << "Omnistat: tracing disabled (initialization failure)" << std::endl;
+        return -1;
+    }
 }
 
 void tool_fini(void* tool_data) {
@@ -305,9 +317,18 @@ void tool_fini(void* tool_data) {
 }
 
 extern "C" rocprofiler_tool_configure_result_t*
-rocprofiler_configure(uint32_t version [[maybe_unused]],
-                      const char* runtime_version [[maybe_unused]],
+rocprofiler_configure(uint32_t version, const char* runtime_version,
                       uint32_t priority [[maybe_unused]], rocprofiler_client_id_t* id) {
+    constexpr uint32_t compiled_version = ROCPROFILER_SDK_VERSION;
+
+    if (version / 10000 != compiled_version / 10000) {
+        std::cerr << "Omnistat: tracing disabled (version mismatch, compiled against "
+                  << compiled_version / 10000 << "." << (compiled_version % 10000) / 100 << "."
+                  << compiled_version % 100 << " but runtime is "
+                  << (runtime_version ? runtime_version : "unknown") << ")" << std::endl;
+        return nullptr;
+    }
+
     id->name = "omnistat-kernel-trace";
 
     auto* tracer = new omnistat::KernelTracer();

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -37,6 +37,7 @@ from flask import Flask
 from prometheus_client.parser import text_string_to_metric_families
 
 import test.config
+import test.workloads as workloads
 from omnistat.monitor import Monitor
 from omnistat.node_monitoring import OmnistatServer
 from omnistat.utils import runShellCommand
@@ -97,6 +98,10 @@ HOST_METRICS = [
     {"name": "omnistat_host_cpu_num_physical_cores",         "validate": ">=%i" % (cores/2),  "labels": None},
     {"name": "omnistat_host_cpu_num_logical_cores",          "validate": "==%i" % cores,      "labels": None},
     {"name": "omnistat_host_boot_time_seconds",              "validate": ">1000",             "labels": None},
+]
+
+ROCPROFILER_METRICS = [
+    {"name": "omnistat_hardware_counter",                    "validate": ">=0",               "labels": ["source", "card", "name"]},
 ]
 
 # fmt: on
@@ -167,6 +172,17 @@ COLLECTOR_CONFIGS = [
         "collectors": ["host_metrics", "omnistat.collectors.host::enable_proc_io_stats"],
         "metrics": HOST_METRICS,
     },
+    {
+        "collectors": ["rocprofiler"],
+        "metrics": ROCPROFILER_METRICS,
+        "config_sections": {
+            "omnistat.collectors.rocprofiler": {"profile": "default"},
+            "omnistat.collectors.rocprofiler.default": {
+                "sampling_mode": "constant",
+                "counters": '["GRBM_COUNT", "GRBM_GUI_ACTIVE"]',
+            },
+        },
+    },
     # general info metrics expected to be present regardless of collector config
     {
         "collectors": ["rocm_smi"],
@@ -194,13 +210,13 @@ ops = {
 
 
 class OmnistatTestServer:
-    def __init__(self, collectors):
+    def __init__(self, collectors, config_sections=None):
         self.address = f"localhost:{test.config.port}"
         self.url = f"http://{self.address}/metrics"
         self.timeout = 5.0
         self.collectors = collectors
 
-        config = self.generate_config(self.collectors)
+        config = self.generate_config(self.collectors, config_sections=config_sections)
         monitor = Monitor(config)
 
         def post_fork(server, worker):
@@ -228,7 +244,7 @@ class OmnistatTestServer:
                 self._process.join(timeout=1)
         time.sleep(1.0)
 
-    def generate_config(self, enabled_collectors):
+    def generate_config(self, enabled_collectors, config_sections=None):
         config = configparser.ConfigParser()
         collectors = {"rocm_path": test.config.rocm_path}
 
@@ -243,6 +259,11 @@ class OmnistatTestServer:
                 collectors[f"enable_{collector}"] = True
 
         config["omnistat.collectors"] = collectors
+
+        if config_sections:
+            for section, options in config_sections.items():
+                config[section] = options
+
         return config
 
     def wait_for_server(self):
@@ -269,7 +290,8 @@ class OmnistatTestServer:
 # Fixture to manage server lifecycle
 @pytest.fixture(scope="class")
 def server(request):
-    server = OmnistatTestServer(request.param)
+    collectors, config_sections = request.param
+    server = OmnistatTestServer(collectors, config_sections=config_sections)
     yield server
     server.stop()
 
@@ -303,8 +325,9 @@ def pytest_generate_tests(metafunc):
         argvalues = []
         ids = []
         for config in COLLECTOR_CONFIGS:
+            config_sections = config.get("config_sections")
             for metric in config["metrics"]:
-                argvalues.append((config["collectors"], metric))
+                argvalues.append(((config["collectors"], config_sections), metric))
                 collector_config = config["collectors"].copy()
                 if len(collector_config) > 1:
                     if "::" in collector_config[1]:
@@ -353,3 +376,39 @@ class TestCollectors:
         threshold = float(num_str)
 
         assert ops[op_str](value, threshold), f"Invalid value for {name} (expecting {validate_expr}, received {value})"
+
+
+class TestHardwareCounters:
+    @pytest.mark.skipif(not test.config.rocm_host, reason="requires ROCm")
+    def test_counters_with_workload(self):
+        config_sections = {
+            "omnistat.collectors.rocprofiler": {"profile": "default"},
+            "omnistat.collectors.rocprofiler.default": {
+                "sampling_mode": "constant",
+                "counters": '["GRBM_COUNT", "GRBM_GUI_ACTIVE", "SQ_INSTS_VALU"]',
+            },
+        }
+        server = OmnistatTestServer(["rocprofiler"], config_sections=config_sections)
+
+        # Run GPU workload with HSA_TOOLS_LIB so the profiler can intercept
+        # application-level PMC counter activity.
+        hsa_tools_lib = os.path.join(test.config.rocm_path, "lib", "librocprofiler64.so")
+        result = workloads.run("vector_add", [1000000], env={"HSA_TOOLS_LIB": hsa_tools_lib})
+        assert result.returncode == 0, f"vector_add failed: {result.stderr}"
+
+        # Scrape metrics
+        metrics = {}
+        for metric in server.get():
+            for sample in metric.samples:
+                key = (metric.name, sample.labels.get("name", ""))
+                metrics[key] = sample.value
+
+        server.stop()
+
+        # Validate counters are non-zero
+        assert ("omnistat_hardware_counter", "GRBM_COUNT") in metrics
+        assert metrics[("omnistat_hardware_counter", "GRBM_COUNT")] > 0
+        assert ("omnistat_hardware_counter", "GRBM_GUI_ACTIVE") in metrics
+        assert metrics[("omnistat_hardware_counter", "GRBM_GUI_ACTIVE")] > 0
+        assert ("omnistat_hardware_counter", "SQ_INSTS_VALU") in metrics
+        assert metrics[("omnistat_hardware_counter", "SQ_INSTS_VALU")] > 0

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -267,7 +267,7 @@ class OmnistatTestServer:
 
 
 # Fixture to manage server lifecycle
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="class")
 def server(request):
     server = OmnistatTestServer(request.param)
     yield server
@@ -311,7 +311,7 @@ def pytest_generate_tests(metafunc):
                         collector_config[1] = collector_config[1].split("::", 1)[1]
                 ids.append(f"{'+'.join(collector_config)}::{metric['name']}")
         # Parametrize server (indirect via fixture) and metric together without cross-product
-        metafunc.parametrize(("server", "desired_metric"), argvalues, ids=ids, scope="session", indirect=["server"])
+        metafunc.parametrize(("server", "desired_metric"), argvalues, ids=ids, scope="class", indirect=["server"])
 
 
 class TestCollectors:

--- a/test/test_endpoint_collectors.py
+++ b/test/test_endpoint_collectors.py
@@ -38,6 +38,13 @@ import test.config
 import test.workloads as workloads
 from omnistat.collector_kernel_trace import KernelTrace
 
+requires_rocm = pytest.mark.skipif(not test.config.rocm_host, reason="requires ROCm")
+
+requires_tracing = pytest.mark.skipif(
+    not test.config.rocm_host or "ROCP_TOOL_LIBRARIES" not in os.environ,
+    reason="requires ROCm and ROCP_TOOL_LIBRARIES",
+)
+
 METRIC_KERNEL_DROPPED = "omnistat_kernel_dropped_dispatches"
 METRIC_KERNEL_DISPATCH_COUNT = "omnistat_kernel_dispatch_count"
 METRIC_KERNEL_TOTAL_DURATION = "omnistat_kernel_total_duration_ns"
@@ -105,23 +112,47 @@ class StandaloneTestServer:
         self._thread.join(timeout=3)
 
 
+def assert_no_drops(metrics):
+    assert METRIC_KERNEL_DROPPED in metrics
+    for label_set, values in metrics[METRIC_KERNEL_DROPPED].items():
+        assert set(dict(label_set).keys()) == {"instance"}
+        assert all(v == 0 for v in values)
+
+
+def assert_dispatches(metrics, expected):
+    assert METRIC_KERNEL_DISPATCH_COUNT in metrics
+    assert METRIC_KERNEL_TOTAL_DURATION in metrics
+
+    assert len(metrics[METRIC_KERNEL_TOTAL_DURATION]) == len(
+        metrics[METRIC_KERNEL_DISPATCH_COUNT]
+    ), "Mismatch between duration and dispatch count label sets"
+
+    for label_set, values in metrics[METRIC_KERNEL_DISPATCH_COUNT].items():
+        assert set(dict(label_set).keys()) == {"instance", "card", "kernel"}
+        assert all(v > 0 for v in values)
+        assert all(a <= b for a, b in zip(values, values[1:]))
+
+    for label_set, values in metrics[METRIC_KERNEL_TOTAL_DURATION].items():
+        assert set(dict(label_set).keys()) == {"instance", "card", "kernel"}
+        assert all(v > 0 for v in values)
+
+    total = sum(v[-1] for v in metrics[METRIC_KERNEL_DISPATCH_COUNT].values())
+    assert total == expected
+
+
 class TestKernelTraceCollector:
-    @pytest.mark.skipif(not test.config.rocm_host, reason="requires ROCm")
-    def test_kernel_trace_no_application(self):
+    @requires_rocm
+    def test_no_application(self):
         server = StandaloneTestServer(KernelTrace)
         time.sleep(2)
         metrics = server.get_metrics(flush=True)
         server.stop()
 
-        assert METRIC_KERNEL_DROPPED in metrics
-        for label_set, values in metrics[METRIC_KERNEL_DROPPED].items():
-            assert set(dict(label_set).keys()) == {"instance"}
-            assert all(v == 0 for v in values)
+        assert_no_drops(metrics)
 
-    @pytest.mark.skipif(not test.config.rocm_host, reason="requires ROCm")
-    @pytest.mark.skipif("ROCP_TOOL_LIBRARIES" not in os.environ, reason="ROCP_TOOL_LIBRARIES not set")
+    @requires_tracing
     @pytest.mark.parametrize("num_kernels", [1, 100, 1000, 10000])
-    def test_kernel_trace_with_application(self, num_kernels):
+    def test_application(self, num_kernels):
         server = StandaloneTestServer(KernelTrace)
         result = workloads.run(
             "launch_kernels",
@@ -133,40 +164,121 @@ class TestKernelTraceCollector:
 
         assert result.returncode == 0, f"launch_kernels failed: {result.stderr}"
 
-        assert METRIC_KERNEL_DROPPED in metrics
-        assert METRIC_KERNEL_TOTAL_DURATION in metrics
-        assert METRIC_KERNEL_DISPATCH_COUNT in metrics
+        assert_no_drops(metrics)
+        assert_dispatches(metrics, expected=num_kernels)
 
-        assert len(metrics[METRIC_KERNEL_DROPPED]) > 0
-        assert len(metrics[METRIC_KERNEL_TOTAL_DURATION]) > 0
-        assert len(metrics[METRIC_KERNEL_DISPATCH_COUNT]) > 0
-
-        assert len(metrics[METRIC_KERNEL_TOTAL_DURATION]) == len(
-            metrics[METRIC_KERNEL_DISPATCH_COUNT]
-        ), "Mismatch between number of dispatch metrics"
-
-        # Check dropped dispatches
-        for label_set, values in metrics[METRIC_KERNEL_DROPPED].items():
-            labels = dict(label_set)
-            assert set(labels.keys()) == {"instance"}
-            assert all(v == 0 for v in values)
-
-        # Check durations
-        for label_set, values in metrics[METRIC_KERNEL_TOTAL_DURATION].items():
-            labels = dict(label_set)
-            assert set(labels.keys()) == {"instance", "card", "kernel"}
-            assert all(v > 0 for v in values)
-
-        # Check dispatch counts
-        for label_set, values in metrics[METRIC_KERNEL_DISPATCH_COUNT].items():
-            labels = dict(label_set)
-            assert set(labels.keys()) == {"instance", "card", "kernel"}
+        # Check kernel name
+        for label_set in metrics[METRIC_KERNEL_DISPATCH_COUNT]:
             assert re.fullmatch(
                 r"(void )?empty_kernel\(\) \[clone \.kd\]",
-                labels["kernel"],
+                dict(label_set)["kernel"],
             )
-            assert all(v > 0 for v in values)
-            assert all(a <= b for a, b in zip(values, values[1:]))
 
-        total_dispatches = sum(values[-1] for values in metrics[METRIC_KERNEL_DISPATCH_COUNT].values())
-        assert total_dispatches == num_kernels
+    @requires_tracing
+    def test_sequential_workloads(self):
+        server = StandaloneTestServer(KernelTrace)
+        workloads.run(
+            "launch_kernels",
+            [30],
+            env={"OMNISTAT_TRACE_ENDPOINT_PORT": str(server._port)},
+        )
+        workloads.run(
+            "launch_kernels",
+            [70],
+            env={"OMNISTAT_TRACE_ENDPOINT_PORT": str(server._port)},
+        )
+        metrics = server.get_metrics(flush=True)
+        server.stop()
+
+        assert_no_drops(metrics)
+        assert_dispatches(metrics, expected=100)
+
+    @requires_tracing
+    def test_cumulative_flushes(self):
+        server = StandaloneTestServer(KernelTrace)
+        workloads.run(
+            "launch_kernels",
+            [50],
+            env={"OMNISTAT_TRACE_ENDPOINT_PORT": str(server._port)},
+        )
+        metrics1 = server.get_metrics(flush=True)
+        workloads.run(
+            "launch_kernels",
+            [50],
+            env={"OMNISTAT_TRACE_ENDPOINT_PORT": str(server._port)},
+        )
+        metrics2 = server.get_metrics(flush=True)
+        server.stop()
+
+        assert_no_drops(metrics1)
+        assert_no_drops(metrics2)
+        assert_dispatches(metrics1, expected=50)
+        assert_dispatches(metrics2, expected=100)
+
+    @requires_tracing
+    def test_delayed_dispatches(self):
+        # 50 kernels with 30ms delay = ~1.5s, spanning multiple 0.5s bins
+        server = StandaloneTestServer(KernelTrace, interval=0.5)
+        result = workloads.run(
+            "launch_kernels",
+            [50, 30000],
+            env={"OMNISTAT_TRACE_ENDPOINT_PORT": str(server._port)},
+        )
+        metrics = server.get_metrics(flush=True)
+        server.stop()
+
+        assert result.returncode == 0, f"launch_kernels failed: {result.stderr}"
+
+        assert_no_drops(metrics)
+        assert_dispatches(metrics, expected=50)
+
+        # ~1.5s across 0.5s bins should produce approximately 3 bins. Allowing
+        # some extra bins related to server startup.
+        num_bins = len(next(iter(metrics[METRIC_KERNEL_DROPPED].values())))
+        assert 3 <= num_bins <= 5
+
+    @requires_tracing
+    def test_scrape_during_workload(self):
+        server = StandaloneTestServer(KernelTrace, interval=0.5)
+        result = None
+
+        def run_workload():
+            nonlocal result
+            # 100 kernels with 40ms delay = ~4 seconds
+            result = workloads.run(
+                "launch_kernels",
+                [100, 40000],
+                env={"OMNISTAT_TRACE_ENDPOINT_PORT": str(server._port)},
+            )
+
+        t = threading.Thread(target=run_workload)
+        t.start()
+
+        # Scrape mid-run with flush=False (mirrors real Omnistat scrape)
+        time.sleep(2)
+        metrics1 = server.get_metrics(flush=False)
+
+        t.join(timeout=30)
+        metrics2 = server.get_metrics(flush=True)
+        server.stop()
+
+        assert result is not None
+        assert result.returncode == 0
+
+        # Mid-run scrape with flush=False: all bins are within the 15s hold
+        # window, so nothing should be released yet
+        assert metrics1 == {}
+
+        assert_no_drops(metrics2)
+        assert_dispatches(metrics2, expected=100)
+
+    @requires_tracing
+    def test_collector_unreachable(self):
+        result = workloads.run(
+            "launch_kernels",
+            [10],
+            env={"OMNISTAT_TRACE_ENDPOINT_PORT": "19998"},
+        )
+        assert result.returncode == 0, (
+            f"launch_kernels should exit 0 even when collector is unreachable; " f"stderr: {result.stderr}"
+        )

--- a/test/test_endpoint_collectors.py
+++ b/test/test_endpoint_collectors.py
@@ -105,6 +105,10 @@ class StandaloneTestServer:
                 results.setdefault(sample.name, {}).setdefault(key, []).append(sample.value)
         return results
 
+    @property
+    def trace_env(self):
+        return {"OMNISTAT_TRACE_ENDPOINT_PORT": str(self._port)}
+
     def stop(self):
         if self._http_server is not None:
             self._http_server.shutdown()
@@ -154,11 +158,7 @@ class TestKernelTraceCollector:
     @pytest.mark.parametrize("num_kernels", [1, 100, 1000, 10000])
     def test_application(self, num_kernels):
         server = StandaloneTestServer(KernelTrace)
-        result = workloads.run(
-            "launch_kernels",
-            [num_kernels],
-            env={"OMNISTAT_TRACE_ENDPOINT_PORT": str(server._port)},
-        )
+        result = workloads.run("launch_kernels", [num_kernels], env=server.trace_env)
         metrics = server.get_metrics(flush=True)
         server.stop()
 
@@ -177,16 +177,8 @@ class TestKernelTraceCollector:
     @requires_tracing
     def test_sequential_workloads(self):
         server = StandaloneTestServer(KernelTrace)
-        workloads.run(
-            "launch_kernels",
-            [30],
-            env={"OMNISTAT_TRACE_ENDPOINT_PORT": str(server._port)},
-        )
-        workloads.run(
-            "launch_kernels",
-            [70],
-            env={"OMNISTAT_TRACE_ENDPOINT_PORT": str(server._port)},
-        )
+        workloads.run("launch_kernels", [30], env=server.trace_env)
+        workloads.run("launch_kernels", [70], env=server.trace_env)
         metrics = server.get_metrics(flush=True)
         server.stop()
 
@@ -196,17 +188,9 @@ class TestKernelTraceCollector:
     @requires_tracing
     def test_cumulative_flushes(self):
         server = StandaloneTestServer(KernelTrace)
-        workloads.run(
-            "launch_kernels",
-            [50],
-            env={"OMNISTAT_TRACE_ENDPOINT_PORT": str(server._port)},
-        )
+        workloads.run("launch_kernels", [50], env=server.trace_env)
         metrics1 = server.get_metrics(flush=True)
-        workloads.run(
-            "launch_kernels",
-            [50],
-            env={"OMNISTAT_TRACE_ENDPOINT_PORT": str(server._port)},
-        )
+        workloads.run("launch_kernels", [50], env=server.trace_env)
         metrics2 = server.get_metrics(flush=True)
         server.stop()
 
@@ -219,11 +203,7 @@ class TestKernelTraceCollector:
     def test_delayed_dispatches(self):
         # 50 kernels with 30ms delay = ~1.5s, spanning multiple 0.5s bins
         server = StandaloneTestServer(KernelTrace, interval=0.5)
-        result = workloads.run(
-            "launch_kernels",
-            [50, 30000],
-            env={"OMNISTAT_TRACE_ENDPOINT_PORT": str(server._port)},
-        )
+        result = workloads.run("launch_kernels", [50, 30000], env=server.trace_env)
         metrics = server.get_metrics(flush=True)
         server.stop()
 
@@ -245,11 +225,7 @@ class TestKernelTraceCollector:
         def run_workload():
             nonlocal result
             # 100 kernels with 40ms delay = ~4 seconds
-            result = workloads.run(
-                "launch_kernels",
-                [100, 40000],
-                env={"OMNISTAT_TRACE_ENDPOINT_PORT": str(server._port)},
-            )
+            result = workloads.run("launch_kernels", [100, 40000], env=server.trace_env)
 
         t = threading.Thread(target=run_workload)
         t.start()
@@ -274,11 +250,7 @@ class TestKernelTraceCollector:
 
     @requires_tracing
     def test_collector_unreachable(self):
-        result = workloads.run(
-            "launch_kernels",
-            [10],
-            env={"OMNISTAT_TRACE_ENDPOINT_PORT": "19998"},
-        )
+        result = workloads.run("launch_kernels", [10], env={"OMNISTAT_TRACE_ENDPOINT_PORT": "19998"})
         assert result.returncode == 0, (
             f"launch_kernels should exit 0 even when collector is unreachable; " f"stderr: {result.stderr}"
         )

--- a/test/test_endpoint_collectors.py
+++ b/test/test_endpoint_collectors.py
@@ -126,9 +126,7 @@ class TestKernelTraceCollector:
         result = workloads.run(
             "launch_kernels",
             [num_kernels],
-            env={
-                "OMNISTAT_TRACE_ENDPOINT_PORT": test.config.port,
-            },
+            env={"OMNISTAT_TRACE_ENDPOINT_PORT": test.config.port},
         )
         metrics = server.get_metrics(flush=True)
         server.stop()

--- a/test/test_endpoint_collectors.py
+++ b/test/test_endpoint_collectors.py
@@ -59,14 +59,14 @@ class StandaloneTestServer:
         self.label_defaults = 'instance="test"'
 
         self._address = "127.0.0.1"
-        self._port = test.config.port
         self._timeout = 5
 
         self._stop_event = threading.Event()
         self._thread = threading.Thread(target=self._update_loop, daemon=True)
         self._thread.start()
 
-        self._http_server = make_server(self._address, self._port, self.app)
+        self._http_server = make_server(self._address, 0, self.app)
+        self._port = self._http_server.socket.getsockname()[1]
         self._http_thread = threading.Thread(target=self._http_server.serve_forever, daemon=True)
         self._http_thread.start()
         self._wait_for_server()
@@ -126,7 +126,7 @@ class TestKernelTraceCollector:
         result = workloads.run(
             "launch_kernels",
             [num_kernels],
-            env={"OMNISTAT_TRACE_ENDPOINT_PORT": test.config.port},
+            env={"OMNISTAT_TRACE_ENDPOINT_PORT": str(server._port)},
         )
         metrics = server.get_metrics(flush=True)
         server.stop()

--- a/test/test_endpoint_collectors.py
+++ b/test/test_endpoint_collectors.py
@@ -23,17 +23,26 @@
 # -------------------------------------------------------------------------------
 
 import configparser
+import os
+import re
 import threading
 import time
 
 import pytest
+import requests
 from flask import Flask
 from prometheus_client.parser import text_string_to_metric_families
+from werkzeug.serving import make_server
 
 import test.config
+import test.workloads as workloads
 from omnistat.collector_kernel_trace import KernelTrace
 
+TRACE_LIB = os.path.join(os.path.dirname(__file__), "..", "..", "build", "libomnistat_trace.so")
+
 METRIC_KERNEL_DROPPED = "omnistat_kernel_dropped_dispatches"
+METRIC_KERNEL_DISPATCH_COUNT = "omnistat_kernel_dispatch_count"
+METRIC_KERNEL_TOTAL_DURATION = "omnistat_kernel_total_duration_ns"
 
 
 class StandaloneTestServer:
@@ -51,26 +60,49 @@ class StandaloneTestServer:
         self.collector = collector_cls(config=self.config, route=self.app.route, interval=interval)
         self.label_defaults = 'instance="test"'
 
+        self._address = "127.0.0.1"
+        self._port = test.config.port
+        self._timeout = 5
+
         self._stop_event = threading.Event()
         self._thread = threading.Thread(target=self._update_loop, daemon=True)
         self._thread.start()
+
+        self._http_server = make_server(self._address, self._port, self.app)
+        self._http_thread = threading.Thread(target=self._http_server.serve_forever, daemon=True)
+        self._http_thread.start()
+        self._wait_for_server()
 
     def _update_loop(self):
         while not self._stop_event.is_set():
             self.collector.updateMetrics()
             self._stop_event.wait(self.interval)
 
+    def _wait_for_server(self):
+        url = f"http://{self._address}:{self._port}/"
+        deadline = time.monotonic() + self._timeout
+        while time.monotonic() < deadline:
+            try:
+                requests.get(url, timeout=0.1)
+                return
+            except requests.ConnectionError:
+                time.sleep(0.05)
+        raise TimeoutError(f"Server did not start within {self._timeout}s")
+
     def get_metrics(self, flush=False):
-        """Return a list of (name, labels, value) tuples."""
+        """Return {name: {frozenset(labels): [values]}}."""
         lines = list(self.collector.formatMetrics(self.label_defaults, flush=flush))
         text = b"".join(lines).decode()
-        results = []
+        results = {}
         for family in text_string_to_metric_families(text):
             for sample in family.samples:
-                results.append((sample.name, sample.labels, sample.value))
+                key = frozenset(sample.labels.items())
+                results.setdefault(sample.name, {}).setdefault(key, []).append(sample.value)
         return results
 
     def stop(self):
+        if self._http_server is not None:
+            self._http_server.shutdown()
         self._stop_event.set()
         self._thread.join(timeout=3)
 
@@ -83,9 +115,62 @@ class TestKernelTraceCollector:
         metrics = server.get_metrics(flush=True)
         server.stop()
 
-        assert len(metrics) > 0, "No metrics found"
+        assert METRIC_KERNEL_DROPPED in metrics
+        for label_set, values in metrics[METRIC_KERNEL_DROPPED].items():
+            assert set(dict(label_set).keys()) == {"instance"}
+            assert all(v == 0 for v in values)
 
-        for name, labels, value in metrics:
-            assert name == METRIC_KERNEL_DROPPED, f"Unexpected metric {name}"
-            assert set(labels.keys()) == {"instance"}, f"Unexpected labels for {name}: {labels}"
-            assert value == 0, f"Invalid value for {name} (expecting 0, received {value})"
+    @pytest.mark.skipif(not test.config.rocm_host, reason="requires ROCm")
+    @pytest.mark.parametrize("num_kernels", [1, 100, 1000, 10000])
+    def test_kernel_trace_with_application(self, num_kernels):
+        server = StandaloneTestServer(KernelTrace)
+        result = workloads.run(
+            "launch_kernels",
+            [num_kernels],
+            env={
+                "ROCP_TOOL_LIBRARIES": os.path.abspath(TRACE_LIB),
+                "OMNISTAT_TRACE_ENDPOINT_PORT": test.config.port,
+            },
+        )
+        metrics = server.get_metrics(flush=True)
+        server.stop()
+
+        assert result.returncode == 0, f"launch_kernels failed: {result.stderr}"
+
+        assert METRIC_KERNEL_DROPPED in metrics
+        assert METRIC_KERNEL_TOTAL_DURATION in metrics
+        assert METRIC_KERNEL_DISPATCH_COUNT in metrics
+
+        assert len(metrics[METRIC_KERNEL_DROPPED]) > 0
+        assert len(metrics[METRIC_KERNEL_TOTAL_DURATION]) > 0
+        assert len(metrics[METRIC_KERNEL_DISPATCH_COUNT]) > 0
+
+        assert len(metrics[METRIC_KERNEL_TOTAL_DURATION]) == len(
+            metrics[METRIC_KERNEL_DISPATCH_COUNT]
+        ), "Mismatch between number of dispatch metrics"
+
+        # Check dropped dispatches
+        for label_set, values in metrics[METRIC_KERNEL_DROPPED].items():
+            labels = dict(label_set)
+            assert set(labels.keys()) == {"instance"}
+            assert all(v == 0 for v in values)
+
+        # Check durations
+        for label_set, values in metrics[METRIC_KERNEL_TOTAL_DURATION].items():
+            labels = dict(label_set)
+            assert set(labels.keys()) == {"instance", "card", "kernel"}
+            assert all(v > 0 for v in values)
+
+        # Check dispatch counts
+        for label_set, values in metrics[METRIC_KERNEL_DISPATCH_COUNT].items():
+            labels = dict(label_set)
+            assert set(labels.keys()) == {"instance", "card", "kernel"}
+            assert re.fullmatch(
+                r"(void )?empty_kernel\(\) \[clone \.kd\]",
+                labels["kernel"],
+            )
+            assert all(v > 0 for v in values)
+            assert all(a <= b for a, b in zip(values, values[1:]))
+
+        total_dispatches = sum(values[-1] for values in metrics[METRIC_KERNEL_DISPATCH_COUNT].values())
+        assert total_dispatches == num_kernels

--- a/test/test_endpoint_collectors.py
+++ b/test/test_endpoint_collectors.py
@@ -186,20 +186,6 @@ class TestKernelTraceCollector:
         assert_dispatches(metrics, expected=100)
 
     @requires_tracing
-    def test_cumulative_flushes(self):
-        server = StandaloneTestServer(KernelTrace)
-        workloads.run("launch_kernels", [50], env=server.trace_env)
-        metrics1 = server.get_metrics(flush=True)
-        workloads.run("launch_kernels", [50], env=server.trace_env)
-        metrics2 = server.get_metrics(flush=True)
-        server.stop()
-
-        assert_no_drops(metrics1)
-        assert_no_drops(metrics2)
-        assert_dispatches(metrics1, expected=50)
-        assert_dispatches(metrics2, expected=100)
-
-    @requires_tracing
     def test_delayed_dispatches(self):
         # 50 kernels with 30ms delay = ~1.5s, spanning multiple 0.5s bins
         server = StandaloneTestServer(KernelTrace, interval=0.5)

--- a/test/test_endpoint_collectors.py
+++ b/test/test_endpoint_collectors.py
@@ -38,8 +38,6 @@ import test.config
 import test.workloads as workloads
 from omnistat.collector_kernel_trace import KernelTrace
 
-TRACE_LIB = os.path.join(os.path.dirname(__file__), "..", "..", "build", "libomnistat_trace.so")
-
 METRIC_KERNEL_DROPPED = "omnistat_kernel_dropped_dispatches"
 METRIC_KERNEL_DISPATCH_COUNT = "omnistat_kernel_dispatch_count"
 METRIC_KERNEL_TOTAL_DURATION = "omnistat_kernel_total_duration_ns"
@@ -121,6 +119,7 @@ class TestKernelTraceCollector:
             assert all(v == 0 for v in values)
 
     @pytest.mark.skipif(not test.config.rocm_host, reason="requires ROCm")
+    @pytest.mark.skipif("ROCP_TOOL_LIBRARIES" not in os.environ, reason="ROCP_TOOL_LIBRARIES not set")
     @pytest.mark.parametrize("num_kernels", [1, 100, 1000, 10000])
     def test_kernel_trace_with_application(self, num_kernels):
         server = StandaloneTestServer(KernelTrace)
@@ -128,7 +127,6 @@ class TestKernelTraceCollector:
             "launch_kernels",
             [num_kernels],
             env={
-                "ROCP_TOOL_LIBRARIES": os.path.abspath(TRACE_LIB),
                 "OMNISTAT_TRACE_ENDPOINT_PORT": test.config.port,
             },
         )

--- a/test/test_endpoint_collectors.py
+++ b/test/test_endpoint_collectors.py
@@ -72,8 +72,8 @@ class StandaloneTestServer:
         self._thread = threading.Thread(target=self._update_loop, daemon=True)
         self._thread.start()
 
-        self._http_server = make_server(self._address, 0, self.app)
-        self._port = self._http_server.socket.getsockname()[1]
+        self._port = int(test.config.port)
+        self._http_server = make_server(self._address, self._port, self.app)
         self._http_thread = threading.Thread(target=self._http_server.serve_forever, daemon=True)
         self._http_thread.start()
         self._wait_for_server()

--- a/test/workloads/Makefile
+++ b/test/workloads/Makefile
@@ -1,4 +1,5 @@
 SOURCES := $(wildcard *.cpp)
+HEADERS := $(wildcard *.hpp)
 TARGETS := $(SOURCES:.cpp=)
 
 all: $(TARGETS)
@@ -7,7 +8,7 @@ OFFLOAD_ARCH ?=
 
 HIPCC_FLAGS := $(foreach arch,$(OFFLOAD_ARCH),--offload-arch=$(arch))
 
-%: %.cpp
+%: %.cpp $(HEADERS)
 	hipcc $(HIPCC_FLAGS) $< -o $@
 
 clean:

--- a/test/workloads/Makefile
+++ b/test/workloads/Makefile
@@ -1,0 +1,12 @@
+SOURCES := $(wildcard *.cpp)
+TARGETS := $(SOURCES:.cpp=)
+
+all: $(TARGETS)
+
+%: %.cpp
+	hipcc $< -o $@
+
+clean:
+	rm -f $(TARGETS)
+
+.PHONY: all clean

--- a/test/workloads/Makefile
+++ b/test/workloads/Makefile
@@ -3,8 +3,12 @@ TARGETS := $(SOURCES:.cpp=)
 
 all: $(TARGETS)
 
+OFFLOAD_ARCH ?=
+
+HIPCC_FLAGS := $(foreach arch,$(OFFLOAD_ARCH),--offload-arch=$(arch))
+
 %: %.cpp
-	hipcc $< -o $@
+	hipcc $(HIPCC_FLAGS) $< -o $@
 
 clean:
 	rm -f $(TARGETS)

--- a/test/workloads/__init__.py
+++ b/test/workloads/__init__.py
@@ -1,0 +1,56 @@
+# ---------------------------------------------------------------------------
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ---------------------------------------------------------------------------
+"""Run HIP test workloads from the test/workloads/ directory."""
+
+import os
+import subprocess
+
+WORKLOADS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def run(name, args=None, env=None):
+    """Run a previously built HIP test workload.
+
+    Args:
+        name: Workload name (target name, without extension).
+        args: List of command-line arguments to pass to the sample.
+        env: Optional environment dict, merged on top of the current
+             environment.
+
+    Returns:
+        subprocess.CompletedProcess
+
+    Raises:
+        FileNotFoundError: If the binary does not exist (run build() first).
+    """
+    binary = os.path.join(WORKLOADS_DIR, name)
+    if not os.path.exists(binary):
+        raise FileNotFoundError(f"Binary not found: {binary} (run build() first)")
+
+    run_env = os.environ.copy()
+    if env:
+        run_env.update(env)
+
+    cmd = [binary] + [str(a) for a in (args or [])]
+    return subprocess.run(cmd, capture_output=True, text=True, env=run_env)

--- a/test/workloads/common.hpp
+++ b/test/workloads/common.hpp
@@ -22,39 +22,18 @@
 // IN THE SOFTWARE.
 // ---------------------------------------------------------------------------
 
-// Simple HIP application that launches a configurable number of GPU kernels.
-// Intended for testing kernel tracing with omnistat.
-//
-// Usage: launch_kernels <count> [delay_us]
-//   count    - number of kernel launches
-//   delay_us - microseconds to sleep between launches (default: 0)
+#pragma once
 
-#include "common.hpp"
+#include <cstdio>
+#include <cstdlib>
+#include <hip/hip_runtime.h>
 
-#include <unistd.h>
-
-__global__ void empty_kernel() {}
-
-int main(int argc, char *argv[]) {
-  if (argc < 2) {
-    fprintf(stderr, "Usage: %s <count> [delay_us]\n", argv[0]);
-    return 1;
-  }
-
-  int count = atoi(argv[1]);
-  int delay_us = argc > 2 ? atoi(argv[2]) : 0;
-
-  if (count <= 0) {
-    fprintf(stderr, "count must be > 0\n");
-    return 1;
-  }
-
-  for (int i = 0; i < count; i++) {
-    empty_kernel<<<1, 1>>>();
-    if (delay_us > 0)
-      usleep(delay_us);
-  }
-
-  HIP_CHECK(hipDeviceSynchronize());
-  return 0;
-}
+#define HIP_CHECK(call)                                                        \
+  do {                                                                         \
+    hipError_t err = (call);                                                   \
+    if (err != hipSuccess) {                                                   \
+      fprintf(stderr, "HIP error %d: %s at %s:%d\n", err,                     \
+              hipGetErrorString(err), __FILE__, __LINE__);                     \
+      exit(1);                                                                 \
+    }                                                                          \
+  } while (0)

--- a/test/workloads/launch_kernels.cpp
+++ b/test/workloads/launch_kernels.cpp
@@ -1,0 +1,71 @@
+// ---------------------------------------------------------------------------
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ---------------------------------------------------------------------------
+
+// Simple HIP application that launches a configurable number of GPU kernels.
+// Intended for testing kernel tracing with omnistat.
+//
+// Usage: launch_kernels <count> [delay_us]
+//   count    - number of kernel launches
+//   delay_us - microseconds to sleep between launches (default: 0)
+
+#include <cstdio>
+#include <cstdlib>
+#include <hip/hip_runtime.h>
+#include <unistd.h>
+
+#define HIP_CHECK(call)                                                        \
+  do {                                                                         \
+    hipError_t err = (call);                                                   \
+    if (err != hipSuccess) {                                                   \
+      fprintf(stderr, "HIP error %d: %s at %s:%d\n", err,                      \
+              hipGetErrorString(err), __FILE__, __LINE__);                     \
+      exit(1);                                                                 \
+    }                                                                          \
+  } while (0)
+
+__global__ void empty_kernel() {}
+
+int main(int argc, char *argv[]) {
+  if (argc < 2) {
+    fprintf(stderr, "Usage: %s <count> [delay_us]\n", argv[0]);
+    return 1;
+  }
+
+  int count = atoi(argv[1]);
+  int delay_us = argc > 2 ? atoi(argv[2]) : 0;
+
+  if (count <= 0) {
+    fprintf(stderr, "count must be > 0\n");
+    return 1;
+  }
+
+  for (int i = 0; i < count; i++) {
+    empty_kernel<<<1, 1>>>();
+    if (delay_us > 0)
+      usleep(delay_us);
+  }
+
+  HIP_CHECK(hipDeviceSynchronize());
+  return 0;
+}

--- a/test/workloads/vector_add.cpp
+++ b/test/workloads/vector_add.cpp
@@ -1,0 +1,127 @@
+// ---------------------------------------------------------------------------
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ---------------------------------------------------------------------------
+
+// Simple HIP vector addition workload for hardware counter validation.
+// Each element performs one VALU add instruction, ensuring measurable
+// GPU activity for counters like GRBM_GUI_ACTIVE and SQ_INSTS_VALU.
+//
+// Usage: vector_add <num_elements>
+
+#include <cstdio>
+#include <cstdlib>
+#include <hip/hip_runtime.h>
+
+#define HIP_CHECK(call)                                                        \
+  do {                                                                         \
+    hipError_t err = (call);                                                   \
+    if (err != hipSuccess) {                                                   \
+      fprintf(stderr, "HIP error %d: %s at %s:%d\n", err,                     \
+              hipGetErrorString(err), __FILE__, __LINE__);                     \
+      exit(1);                                                                 \
+    }                                                                          \
+  } while (0)
+
+__global__ void vector_add_kernel(const float *A, const float *B, float *C,
+                                  int N) {
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
+  if (i < N) {
+    C[i] = A[i] + B[i];
+  }
+}
+
+int main(int argc, char *argv[]) {
+  if (argc < 2) {
+    fprintf(stderr, "Usage: %s <num_elements>\n", argv[0]);
+    return 1;
+  }
+
+  int N = atoi(argv[1]);
+  if (N <= 0) {
+    fprintf(stderr, "num_elements must be > 0\n");
+    return 1;
+  }
+
+  size_t bytes = N * sizeof(float);
+
+  // Allocate host memory
+  float *h_A = (float *)malloc(bytes);
+  float *h_B = (float *)malloc(bytes);
+  float *h_C = (float *)malloc(bytes);
+
+  if (!h_A || !h_B || !h_C) {
+    fprintf(stderr, "Host allocation failed\n");
+    return 1;
+  }
+
+  // Initialize host vectors
+  for (int i = 0; i < N; i++) {
+    h_A[i] = 1.0f;
+    h_B[i] = 2.0f;
+  }
+
+  // Allocate device memory
+  float *d_A, *d_B, *d_C;
+  HIP_CHECK(hipMalloc(&d_A, bytes));
+  HIP_CHECK(hipMalloc(&d_B, bytes));
+  HIP_CHECK(hipMalloc(&d_C, bytes));
+
+  // Copy to device
+  HIP_CHECK(hipMemcpy(d_A, h_A, bytes, hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(d_B, h_B, bytes, hipMemcpyHostToDevice));
+
+  // Launch kernel
+  int blockSize = 256;
+  int gridSize = (N + blockSize - 1) / blockSize;
+  vector_add_kernel<<<gridSize, blockSize>>>(d_A, d_B, d_C, N);
+  HIP_CHECK(hipDeviceSynchronize());
+
+  // Copy result back
+  HIP_CHECK(hipMemcpy(h_C, d_C, bytes, hipMemcpyDeviceToHost));
+
+  // Verify results
+  int errors = 0;
+  for (int i = 0; i < N; i++) {
+    if (h_C[i] != 3.0f) {
+      errors++;
+      if (errors <= 5) {
+        fprintf(stderr, "Mismatch at %d: expected 3.0, got %f\n", i, h_C[i]);
+      }
+    }
+  }
+
+  // Cleanup
+  HIP_CHECK(hipFree(d_A));
+  HIP_CHECK(hipFree(d_B));
+  HIP_CHECK(hipFree(d_C));
+  free(h_A);
+  free(h_B);
+  free(h_C);
+
+  if (errors > 0) {
+    fprintf(stderr, "FAILED: %d errors\n", errors);
+    return 1;
+  }
+
+  return 0;
+}

--- a/test/workloads/vector_add.cpp
+++ b/test/workloads/vector_add.cpp
@@ -28,19 +28,7 @@
 //
 // Usage: vector_add <num_elements>
 
-#include <cstdio>
-#include <cstdlib>
-#include <hip/hip_runtime.h>
-
-#define HIP_CHECK(call)                                                        \
-  do {                                                                         \
-    hipError_t err = (call);                                                   \
-    if (err != hipSuccess) {                                                   \
-      fprintf(stderr, "HIP error %d: %s at %s:%d\n", err,                     \
-              hipGetErrorString(err), __FILE__, __LINE__);                     \
-      exit(1);                                                                 \
-    }                                                                          \
-  } while (0)
+#include "common.hpp"
 
 __global__ void vector_add_kernel(const float *A, const float *B, float *C,
                                   int N) {


### PR DESCRIPTION
- [x] Add end-to-end tests for kernel tracing using a real HIP application (`launch_kernels`) that dispatches configurable numbers of GPU kernels
- [x] Add endpoint collector tests to `test-gpus.yml` and `test-mi325.yml` CI workflows
- [x] Tests are skipped when `ROCP_TOOL_LIBRARIES` is not set`
- [x] Simplify trace library finalization/flushing, replacing flush-from-callback pattern which may lead to a race