### PR TITLE
ensure ssh startup in user-mode uses known shell

### DIFF
--- a/omnistat/utils.py
+++ b/omnistat/utils.py
@@ -30,6 +30,7 @@ import logging
 import os
 import re
 import resource
+import shlex
 import shutil
 import subprocess
 import sys
@@ -582,8 +583,8 @@ def execute_ssh_command_nohup(
     while attempt <= max_retries:
         try:
             outfile = outputDir + f"/omnistat_launch_{hostname}_try{attempt}.log"
-            nohup_command = f"nohup {command} > {outfile} 2>&1 &"
-            ssh_command = ["ssh", hostname, nohup_command]
+            nohup_command = f"nohup {command} > {shlex.quote(outfile)} 2>&1 &"
+            ssh_command = ["ssh", hostname, "bash", "-c", nohup_command]
 
             logging.debug(f"[pssh] {ssh_command}")
 

--- a/omnistat/utils.py
+++ b/omnistat/utils.py
@@ -584,7 +584,7 @@ def execute_ssh_command_nohup(
         try:
             outfile = outputDir + f"/omnistat_launch_{hostname}_try{attempt}.log"
             nohup_command = f"nohup {command} > {shlex.quote(outfile)} 2>&1 &"
-            ssh_command = ["ssh", hostname, "bash", "-c", nohup_command]
+            ssh_command = ["ssh", hostname, "bash -c " + shlex.quote(nohup_command)]
 
             logging.debug(f"[pssh] {ssh_command}")
 


### PR DESCRIPTION
A user reported an error with user-mode startup with the following signature (which has not been seen before):

```
Launching exporters in parallel via ssh
[pssh] try 1 of 3 failed for compute004: Ambiguous output redirect.
[pssh] try 2 of 3 failed for compute004: Ambiguous output redirect.
[pssh] try 3 of 3 failed for compute004: Ambiguous output redirect.
[pssh] Max retries reached for compute004
[pssh] Failed to launch ssh command on compute004
```

The ambiguous output redirection failure was tracked down to the user having `tcsh` setup as their login shell which is incompatible with redirection commands being used in startup via ssh.  This PR updates the startup process to use `bash` directly.