### PR TITLE
Update  omnistat-usermode utility for single node execution without resource manager

### DIFF
--- a/.github/workflows/test-local-usermode.yml
+++ b/.github/workflows/test-local-usermode.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Usermode (localjob, no RMS)
-    runs-on: [self-hosted, instinct]
+    runs-on: [linux-gfx942-1gpu-ossci-rocm]
     steps:
 
       - name: Check out repository code

--- a/.github/workflows/test-local-usermode.yml
+++ b/.github/workflows/test-local-usermode.yml
@@ -67,7 +67,12 @@ jobs:
 
       - name: Display query output on failure
         if: failure()
-        run: cat query_output.txt
+        run: |
+          echo "-- Query output --"
+          cat query_output.txt
+          echo "---"
+          echo "-- VictoriaMetrics server log --"
+          cat vic_server.log
 
       - name: Stop server
         if: always()

--- a/.github/workflows/test-local-usermode.yml
+++ b/.github/workflows/test-local-usermode.yml
@@ -9,16 +9,11 @@ on:
 jobs:
   test:
     name: Usermode (localjob, no RMS)
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, instinct]
     steps:
 
       - name: Check out repository code
-        uses: actions/checkout@v4
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y python3-venv
+        uses: actions/checkout@v6
 
       - name: Download VictoriaMetrics (latest)
         run: |
@@ -35,10 +30,6 @@ jobs:
           pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-query.txt
-
-      - name: Disable SMI collectors (no GPU hardware available)
-        run: |
-          sed -i "s/enable_rocm_smi = True/enable_rocm_smi = False/" omnistat/config/omnistat.default
 
       - name: Set VictoriaMetrics binary path
         run: |

--- a/.github/workflows/test-local-usermode.yml
+++ b/.github/workflows/test-local-usermode.yml
@@ -1,0 +1,75 @@
+name: User mode - Local
+
+on:
+  workflow_dispatch:
+
+  pull_request:
+    branches: [ main, dev ]
+
+jobs:
+  test:
+    name: Usermode (localjob, no RMS)
+    runs-on: ubuntu-24.04
+    steps:
+
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y python3-venv
+
+      - name: Download VictoriaMetrics (latest)
+        run: |
+          VERSION=$(curl -s https://api.github.com/repos/VictoriaMetrics/VictoriaMetrics/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
+          echo "Installing VictoriaMetrics $VERSION"
+          wget -q https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/${VERSION}/victoria-metrics-linux-amd64-${VERSION}.tar.gz
+          tar xzf victoria-metrics-linux-amd64-${VERSION}.tar.gz
+          chmod +x victoria-metrics-prod
+
+      - name: Create virtual environment
+        run: |
+          python3 -m venv omnistat_venv
+          source omnistat_venv/bin/activate
+          pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Disable SMI collectors (no GPU hardware available)
+        run: |
+          sed -i "s/enable_rocm_smi = True/enable_rocm_smi = False/" omnistat/config/omnistat.default
+
+      - name: Set VictoriaMetrics binary path
+        run: |
+          sed -i "s|victoria_binary = .*|victoria_binary = ${{ github.workspace }}/victoria-metrics-prod|" omnistat/config/omnistat.default
+
+      - name: Start usermode Omnistat
+        run: |
+          source omnistat_venv/bin/activate
+          ./omnistat-usermode --start --interval 1 --localjob 1234
+
+      - name: Wait for samples to be collected
+        run: sleep 10
+
+      - name: Stop exporters
+        if: always()
+        run: |
+          source omnistat_venv/bin/activate
+          ./omnistat-usermode --stopexporters --localjob 1234
+
+      - name: Query job metrics
+        run: |
+          source omnistat_venv/bin/activate
+          ./omnistat-query --interval 1.0 --job 1234 | tee query_output.txt
+          grep -q "Omnistat Report Card" query_output.txt
+          grep -q "GPU Statistics" query_output.txt
+
+      - name: Display query output on failure
+        if: failure()
+        run: cat query_output.txt
+
+      - name: Stop server
+        if: always()
+        run: |
+          source omnistat_venv/bin/activate
+          ./omnistat-usermode --stopserver

--- a/.github/workflows/test-local-usermode.yml
+++ b/.github/workflows/test-local-usermode.yml
@@ -31,9 +31,10 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-query.txt
 
-      - name: Set VictoriaMetrics binary path
+      - name: Update runtime config
         run: |
           sed -i "s|victoria_binary = .*|victoria_binary = ${{ github.workspace }}/victoria-metrics-prod|" omnistat/config/omnistat.default
+          sed -i "s|job_detection_file = .*|job_detection_file = /tmp/omni_rmsjobinfo_ciuser|" omnistat/config/omnistat.default
 
       - name: Start usermode Omnistat
         run: |

--- a/.github/workflows/test-local-usermode.yml
+++ b/.github/workflows/test-local-usermode.yml
@@ -31,10 +31,23 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-query.txt
 
+      - name: Select available exporter port
+        run: |
+          for p in $(seq 8010 8059); do
+            if ! ss -tlnp | grep -q ":${p} "; then
+              echo "OMNISTAT_PORT=$p" >> $GITHUB_ENV
+              echo "Using exporter port $p"
+              exit 0
+            fi
+          done
+          echo "No free port found in range 8010-8059"
+          exit 1
+
       - name: Update runtime config
         run: |
           sed -i "s|victoria_binary = .*|victoria_binary = ${{ github.workspace }}/victoria-metrics-prod|" omnistat/config/omnistat.default
           sed -i "s|job_detection_file = .*|job_detection_file = /tmp/omni_rmsjobinfo_ciuser|" omnistat/config/omnistat.default
+          sed -i "s|port = .*|port = $OMNISTAT_PORT|" omnistat/config/omnistat.default
 
       - name: Start usermode Omnistat
         run: |
@@ -42,7 +55,7 @@ jobs:
           ./omnistat-usermode --start --interval 0.5 --localjob 1234
 
       - name: Verify exporter is listening
-        run: curl -sf localhost:8001/metrics | grep -q "status.*ok"
+        run: curl -sf localhost:$OMNISTAT_PORT/metrics | grep -q "status.*ok"
 
       - name: Wait for samples to be collected
         run: sleep 10

--- a/.github/workflows/test-local-usermode.yml
+++ b/.github/workflows/test-local-usermode.yml
@@ -34,6 +34,7 @@ jobs:
           source omnistat_venv/bin/activate
           pip install --upgrade pip
           pip install -r requirements.txt
+          pip install -r requirements-query.txt
 
       - name: Disable SMI collectors (no GPU hardware available)
         run: |
@@ -46,7 +47,7 @@ jobs:
       - name: Start usermode Omnistat
         run: |
           source omnistat_venv/bin/activate
-          ./omnistat-usermode --start --interval 1 --localjob 1234
+          ./omnistat-usermode --start --interval 0.5 --localjob 1234
 
       - name: Wait for samples to be collected
         run: sleep 10
@@ -60,7 +61,7 @@ jobs:
       - name: Query job metrics
         run: |
           source omnistat_venv/bin/activate
-          ./omnistat-query --interval 1.0 --job 1234 | tee query_output.txt
+          ./omnistat-query --interval 0.5 --job 1234 | tee query_output.txt
           grep -q "Omnistat Report Card" query_output.txt
           grep -q "GPU Statistics" query_output.txt
 

--- a/.github/workflows/test-local-usermode.yml
+++ b/.github/workflows/test-local-usermode.yml
@@ -49,6 +49,9 @@ jobs:
           source omnistat_venv/bin/activate
           ./omnistat-usermode --start --interval 0.5 --localjob 1234
 
+      - name: Verify exporter is listening
+        run: curl -sf localhost:8001/metrics | grep -q "status.*ok"
+
       - name: Wait for samples to be collected
         run: sleep 10
 
@@ -73,6 +76,8 @@ jobs:
           echo "---"
           echo "-- VictoriaMetrics server log --"
           cat vic_server.log
+          echo "-- Exporter log --"
+          cat exporter.log
 
       - name: Stop server
         if: always()

--- a/omnistat/omni_util.py
+++ b/omnistat/omni_util.py
@@ -595,7 +595,11 @@ def main():
     parser.add_argument("--interval", type=float, help="data sampling frequency in secs (default=10)")
     parser.add_argument("--pushinterval", type=float, help="data push frequency in minutes (default=5)", default=5.0)
     parser.add_argument(
-        "--localjob",  metavar="name", type=str, help="run omnistat on local host only with specified job name", default=None
+        "--localjob",
+        metavar="name",
+        type=str,
+        help="run omnistat on local host only with specified job name",
+        default=None,
     )
 
     args = parser.parse_args()

--- a/omnistat/omni_util.py
+++ b/omnistat/omni_util.py
@@ -595,7 +595,7 @@ def main():
     parser.add_argument("--interval", type=float, help="data sampling frequency in secs (default=10)")
     parser.add_argument("--pushinterval", type=float, help="data push frequency in minutes (default=5)", default=5.0)
     parser.add_argument(
-        "--localjob", type=str, help="run omnistat on local host only with specified job name", default=None
+        "--localjob",  metavar="name", type=str, help="run omnistat on local host only with specified job name", default=None
     )
 
     args = parser.parse_args()

--- a/omnistat/omni_util.py
+++ b/omnistat/omni_util.py
@@ -29,6 +29,7 @@ import importlib.resources
 import logging
 import os
 import platform
+import shlex
 import shutil
 import socket
 import subprocess
@@ -320,11 +321,16 @@ class UserBasedMonitoring:
             time.sleep(1)
             return
 
-    def startExporters(self, victoriaMode=False):
+    def startExporters(self, victoriaMode=False, localjob=None):
         port = self.runtimeConfig["omnistat.collectors"].get("port", "8001")
         corebinding = self.runtimeConfig["omnistat.usermode"].getint("exporter_corebinding", None)
 
-        self.rmsDetection()
+        if localjob is not None:
+            rms_mode = False
+            self.__hosts = ["localhost"]
+        else:
+            rms_mode = True
+            self.rmsDetection()
         self.disableProxies()
         self.victoriaModeSetup()
 
@@ -358,11 +364,10 @@ class UserBasedMonitoring:
         else:
             logging.info("[exporter]: Skipping exporter corebinding")
 
-        if self.__hosts:
+        logging.info("[exporter]: Saving RMS job state locally to compute hosts...")
+        detection_file = self.runtimeConfig["omnistat.collectors.rms"].get("job_detection_file", "/tmp/omni_rmsjobinfo")
+        if rms_mode:
             logging.info("[exporter]: Saving RMS job state locally to compute hosts...")
-            detection_file = self.runtimeConfig["omnistat.collectors.rms"].get(
-                "job_detection_file", "/tmp/omni_rmsjobinfo"
-            )
             if self.__rms == "slurm":
                 numNodes = os.getenv("SLURM_JOB_NUM_NODES")
                 srun_cmd = [
@@ -404,14 +409,17 @@ class UserBasedMonitoring:
                     retry_delay=5,
                 )
                 time.sleep(1)
+        else:
+            command = ["%s/omnistat-rms-env" % self.binDir, "--localjob=%s" % localjob, "%s" % detection_file]
+            utils.runShellCommand(command, timeout=10, exit_on_error=True)
 
+        additional_env = ""
+        if self.__external_proxy:
+            additional_env = f"http_proxy={self.__external_proxy}"
+
+        # exporter launch
+        if rms_mode:
             logging.info("Launching exporters in parallel via ssh")
-
-            additional_env = ""
-            if self.__external_proxy:
-                additional_env = f"http_proxy={self.__external_proxy}"
-
-            # trying local ssh client implementation
             launch_results = utils.execute_ssh_parallel(
                 command=f"sh -c 'cd {os.getcwd()} && LD_LIBRARY_PATH={os.getenv('LD_LIBRARY_PATH')} PYTHONPATH={':'.join(sys.path)} {additional_env} {cmd}'",
                 hostnames=self.__hosts,
@@ -420,64 +428,68 @@ class UserBasedMonitoring:
                 max_retries=3,
                 retry_delay=5,
             )
+        else:
+            logging.info("Starting exporter on localhost for job =  %s" % localjob)
+            env_adds = {"http_proxy": self.__external_proxy} if self.__external_proxy else None
+            utils.runBGProcess(shlex.split(cmd), outputFile="exporter.log", envAdds=env_adds)
 
-            # verify exporter available on all nodes...
-            if len(self.__hosts) <= 8:
-                psecs = 5
-            elif len(self.__hosts) <= 128:
-                psecs = 30
-            else:
-                psecs = 90
+        # verify exporter available on all nodes...
+        if len(self.__hosts) <= 8:
+            psecs = 5
+        elif len(self.__hosts) <= 128:
+            psecs = 30
+        else:
+            psecs = 90
 
-            logging.info("Exporters launched, pausing for %i secs" % psecs)
-            time.sleep(psecs)  # <-- needed for slow SLURM query times on ORNL
-            numHosts = len(self.__hosts)
-            numAvail = 0
+        logging.info("Exporters launched, pausing for %i secs" % psecs)
+        time.sleep(psecs)
+        numHosts = len(self.__hosts)
+        numAvail = 0
 
-            if True:
-                logging.info("Testing exporter availability")
-                delay_start = 0.05
-                hosts_ok = []
-                hosts_bad = []
-                for host in self.__hosts:
-                    host_ok = False
-                    for iter in range(1, 25):
-                        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                            try:
-                                result = s.connect_ex((host, int(port)))
+        if True:
+            logging.info("Testing exporter availability")
+            delay_start = 0.05
+            hosts_ok = []
+            hosts_bad = []
+            for host in self.__hosts:
+                host_ok = False
+                for iter in range(1, 25):
+                    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                        try:
+                            result = s.connect_ex((host, int(port)))
 
-                                if result == 0:
-                                    numAvail = numAvail + 1
-                                    hosts_ok.append(host)
-                                    logging.debug("Exporter on %s ok" % host)
-                                    host_ok = True
-                                    break
-                                else:
-                                    delay = delay_start * iter
-                                    logging.debug("Retrying %s (sleeping for %.2f sec)" % (host, delay))
-                                    time.sleep(delay)
-                                s.close()
-                            except Exception as e:
+                            if result == 0:
+                                numAvail = numAvail + 1
+                                hosts_ok.append(host)
+                                logging.debug("Exporter on %s ok" % host)
+                                host_ok = True
                                 break
+                            else:
+                                delay = delay_start * iter
+                                logging.debug("Retrying %s (sleeping for %.2f sec)" % (host, delay))
+                                time.sleep(delay)
+                            s.close()
+                        except Exception as e:
+                            break
 
-                    if not host_ok:
-                        logging.error("Missing exporter on %s (%s)" % (host, result))
-                        hosts_bad.append(host)
+                if not host_ok:
+                    logging.error("Missing exporter on %s (%s)" % (host, result))
+                    hosts_bad.append(host)
 
-                logging.info("%i of %i exporters available" % (numAvail, numHosts))
-                if numAvail == numHosts:
-                    logging.info("User mode data collectors: SUCCESS")
+            logging.info("%i of %i exporters available" % (numAvail, numHosts))
+            if numAvail == numHosts:
+                logging.info("User mode data collectors: SUCCESS")
 
-                # cache any failed hosts to file
-                jobid = os.getenv("SLURM_JOB_ID", None)
-                if jobid:
-                    fileout = "omnistat_failed_hosts.%s.out" % jobid
-                    if hosts_bad:
-                        with open(fileout, "w") as f:
-                            for host in hosts_bad:
-                                f.write(host + "\n")
-                        f.close()
-                        logging.info("Cached failed startup hosts in %s" % fileout)
+            # cache any failed hosts to file
+            jobid = os.getenv("SLURM_JOB_ID", None)
+            if jobid:
+                fileout = "omnistat_failed_hosts.%s.out" % jobid
+                if hosts_bad:
+                    with open(fileout, "w") as f:
+                        for host in hosts_bad:
+                            f.write(host + "\n")
+                    f.close()
+                    logging.info("Cached failed startup hosts in %s" % fileout)
 
         return
 
@@ -491,8 +503,14 @@ class UserBasedMonitoring:
 
         return t2 - t1
 
-    def stopExporters(self, victoriaMode=False):
-        self.rmsDetection()
+    def stopExporters(self, victoriaMode=False, localjob=None):
+
+        if localjob is not None:
+            rms_mode = False
+            self.__hosts = ["localhost"]
+        else:
+            rms_mode = True
+            self.rmsDetection()
         self.disableProxies()
 
         logging.info("Stopping %i exporters" % len(self.__hosts))
@@ -576,6 +594,9 @@ def main():
     parser.add_argument("--stop", help="stop all user-based monitoring services", action="store_true")
     parser.add_argument("--interval", type=float, help="data sampling frequency in secs (default=10)")
     parser.add_argument("--pushinterval", type=float, help="data push frequency in minutes (default=5)", default=5.0)
+    parser.add_argument(
+        "--localjob", type=str, help="run omnistat on local host only with specified job name", default=None
+    )
 
     args = parser.parse_args()
 
@@ -600,18 +621,18 @@ def main():
     elif args.stopserver:
         userUtils.stopPromServer(victoriaMode=victoriaMode)
     elif args.startexporters:
-        userUtils.startExporters(victoriaMode=victoriaMode)
+        userUtils.startExporters(victoriaMode=victoriaMode, localjob=args.localjob)
     elif args.stopexporters:
-        userUtils.stopExporters(victoriaMode=victoriaMode)
+        userUtils.stopExporters(victoriaMode=victoriaMode, localjob=args.localjob)
     elif args.start:
         if victoriaMode:
             logging.info("Initiating data collection in [push] mode -> VictoriaMetrics")
         else:
             logging.info("Initiating data collection in [pull] mode -> Prometheus")
         userUtils.startPromServer(victoriaMode=victoriaMode)
-        userUtils.startExporters(victoriaMode=victoriaMode)
+        userUtils.startExporters(victoriaMode=victoriaMode, localjob=args.localjob)
     elif args.stop:
-        userUtils.stopExporters(victoriaMode=victoriaMode)
+        userUtils.stopExporters(victoriaMode=victoriaMode, localjob=args.localjob)
         userUtils.stopPromServer(victoriaMode=victoriaMode)
     else:
         parser.print_help()

--- a/omnistat/rms_env.py
+++ b/omnistat/rms_env.py
@@ -43,6 +43,13 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--nostep", help="do not cache job step information", action="store_true")
     parser.add_argument(
+        "--localjob",
+        type=str,
+        metavar="name",
+        help="log run with specified job name on localhost (without RMS running)",
+        default=None,
+    )
+    parser.add_argument(
         "output_file",
         type=str,
         nargs="?",
@@ -54,7 +61,16 @@ def main():
     jobFile = args.output_file
     jobData = {}
 
-    if "SLURM_JOB_ID" in os.environ:
+    if args.localjob is not None:
+        jobData["RMS_TYPE"] = "local"
+        jobData["RMS_JOB_ID"] = "%s" % args.localjob
+        jobData["RMS_JOB_USER"] = os.getenv("USER", "unknown")
+        jobData["RMS_JOB_PARTITION"] = "N/A"
+        jobData["RMS_JOB_NUM_NODES"] = 1
+        jobData["RMS_JOB_BATCHMODE"] = 0
+        jobData["RMS_STEP_ID"] = -1
+
+    elif "SLURM_JOB_ID" in os.environ:
         jobData["RMS_TYPE"] = "slurm"
         jobData["RMS_JOB_ID"] = os.getenv("SLURM_JOB_ID")
         jobData["RMS_JOB_USER"] = os.getenv("SLURM_JOB_USER")


### PR DESCRIPTION
This PR introduces a new `--localjob name` option for the usermode utility. The motivation for this addition is for users who would like to use Omnistat on a single node and are not running under a supported resource manager (e.g. local workstation, login node, etc).  In order to allow this and support use of the query utilities, the user can supply their own job identifier with the `--localjob` option and data collection will be spawned on the local host without the need to query slurm, flux, or pbs.  General start/stop/query usage is the same, but the extra option is used to indicate single-node, local execution is desired. 

---

The following highlights running locally with a user prescribed job identifier of "1234":

#### Startup (time series database + data collector)

`$ omnistat-usermode  --start --interval 1 --localjob 1234`

#### Stop data collection

`$ omnistat-usermode  --stopexporters --localjob 1234`

#### Query

```

$ omnistat-query --interval 1.0 --job 1234  
----------------------------------------------------------------------
Omnistat Report Card for Job Id: 1234
----------------------------------------------------------------------

Job Overview (Num Nodes = 1, Machine = My Cluster)
 --> Start time = 2026-04-23 15:51:02
 --> End   time = 2026-04-23 15:51:46
 --> Duration   = 44 secs

GPU Statistics:

           | Utilization (%)  |  Memory Use (%)  | Temperature (C)  |    Power (W)     | Energy (kWh) |
     GPU # |    Max     Mean  |    Max     Mean  |    Max     Mean  |    Max     Mean  |    Total     |
    ---------------------------------------------------------------------------------------------------
         0 |    0.00    0.00  |    0.02    0.02  |   49.00   48.20  |   40.00   40.00  |   4.78e-04   |
         1 |    0.00    0.00  |    0.02    0.02  |   51.00   50.14  |   43.00   43.00  |   5.14e-04   |

Approximate Total GPU Energy Consumed = 9.91e-04 kWh

Host Statistics:

    # CPUs | CPU Utilization (%)  |    Memory Use (%)    |    I/O Data Totals   |
           |    Max       Mean    |    Max       Mean    |    Read      Write   |
    -----------------------------------------------------------------------------
       128 |   40.83     25.26    |   97.39     97.04    |    7.5 GB     2.0 GB |

--
Query interval = 1.000 secs
Query execution time = 0.2 secs
Version = 1.11.0 (a7184a6)
```