### PR TITLE
Fix GPU Kernel panels showing wrong values for kernels with a single data point

### DIFF
--- a/docker/grafana/json-models/job.json
+++ b/docker/grafana/json-models/job.json
@@ -42,8 +42,7 @@
         "x": 0,
         "y": 0
       },
-      "id": 35,
-      "panels": [],
+      "id": 188,
       "title": "Job Info",
       "type": "row"
     },
@@ -57,7 +56,6 @@
           "color": {
             "mode": "fixed"
           },
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -67,8 +65,7 @@
               }
             ]
           }
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 3,
@@ -97,7 +94,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -127,7 +124,6 @@
           "color": {
             "mode": "fixed"
           },
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -137,8 +133,7 @@
               }
             ]
           }
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 3,
@@ -167,7 +162,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -201,7 +196,6 @@
           "color": {
             "mode": "fixed"
           },
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -211,8 +205,7 @@
               }
             ]
           }
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 3,
@@ -241,7 +234,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -299,8 +292,7 @@
               }
             ]
           }
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 3,
@@ -329,7 +321,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -373,7 +365,6 @@
           "color": {
             "mode": "fixed"
           },
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -383,8 +374,7 @@
               }
             ]
           }
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 3,
@@ -413,7 +403,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -442,7 +432,6 @@
           "color": {
             "mode": "fixed"
           },
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -452,8 +441,7 @@
               }
             ]
           }
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 3,
@@ -482,7 +470,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -510,7 +498,6 @@
           "color": {
             "mode": "fixed"
           },
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -521,8 +508,7 @@
             ]
           },
           "unit": "dthms"
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 3,
@@ -551,7 +537,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -560,7 +546,6 @@
           },
           "editorMode": "code",
           "expr": "max(timestamp(rmsjob_info{jobid=\"$jobid\"}))",
-          "hide": false,
           "instant": false,
           "interval": "",
           "legendFormat": "__auto",
@@ -579,8 +564,7 @@
         "x": 0,
         "y": 4
       },
-      "id": 66,
-      "panels": [],
+      "id": 189,
       "title": "Performance Overview",
       "type": "row"
     },
@@ -596,7 +580,6 @@
             "mode": "thresholds"
           },
           "decimals": 0,
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -615,8 +598,7 @@
             ]
           },
           "unit": "percent"
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 4,
@@ -642,7 +624,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -708,7 +690,6 @@
               "mode": "off"
             }
           },
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -775,6 +756,10 @@
       "id": 58,
       "interval": "$interval",
       "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
         "legend": {
           "calcs": [],
           "displayMode": "list",
@@ -788,7 +773,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -809,13 +794,13 @@
           },
           "editorMode": "code",
           "expr": "max(rocm_utilization_percentage * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-          "hide": false,
           "instant": false,
           "legendFormat": "Max",
           "range": true,
           "refId": "B"
         }
       ],
+      "title": "",
       "type": "timeseries"
     },
     {
@@ -830,7 +815,6 @@
             "mode": "thresholds"
           },
           "decimals": 0,
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -849,8 +833,7 @@
             ]
           },
           "unit": "percent"
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 4,
@@ -876,7 +859,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -942,7 +925,6 @@
               "mode": "off"
             }
           },
-          "mappings": [],
           "max": 100,
           "min": 0,
           "thresholds": {
@@ -1011,6 +993,10 @@
       "id": 61,
       "interval": "$interval",
       "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
         "legend": {
           "calcs": [],
           "displayMode": "list",
@@ -1024,7 +1010,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -1045,13 +1031,13 @@
           },
           "editorMode": "code",
           "expr": "max(rocm_vram_used_percentage * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-          "hide": false,
           "instant": false,
           "legendFormat": "Max",
           "range": true,
           "refId": "B"
         }
       ],
+      "title": "",
       "type": "timeseries"
     },
     {
@@ -1066,7 +1052,6 @@
             "mode": "fixed"
           },
           "decimals": 0,
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1085,8 +1070,7 @@
             ]
           },
           "unit": "percent"
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 4,
@@ -1112,7 +1096,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -1176,7 +1160,6 @@
               "mode": "off"
             }
           },
-          "mappings": [],
           "min": 0,
           "thresholds": {
             "mode": "absolute",
@@ -1220,6 +1203,10 @@
       "id": 63,
       "interval": "$interval",
       "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
         "legend": {
           "calcs": [],
           "displayMode": "list",
@@ -1233,7 +1220,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -1248,6 +1235,7 @@
           "refId": "A"
         }
       ],
+      "title": "",
       "type": "timeseries"
     },
     {
@@ -1262,7 +1250,6 @@
             "mode": "thresholds"
           },
           "decimals": 0,
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1281,8 +1268,7 @@
             ]
           },
           "unit": "percent"
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 4,
@@ -1308,7 +1294,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -1374,7 +1360,6 @@
               "mode": "off"
             }
           },
-          "mappings": [],
           "max": 100,
           "min": 0,
           "thresholds": {
@@ -1419,6 +1404,10 @@
       "id": 65,
       "interval": "$interval",
       "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
         "legend": {
           "calcs": [],
           "displayMode": "list",
@@ -1432,7 +1421,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -1447,6 +1436,7 @@
           "refId": "A"
         }
       ],
+      "title": "",
       "type": "timeseries"
     },
     {
@@ -1461,7 +1451,6 @@
             "mode": "fixed"
           },
           "decimals": 0,
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1480,8 +1469,7 @@
             ]
           },
           "unit": "binBps"
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 4,
@@ -1508,7 +1496,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -1530,7 +1518,6 @@
           },
           "editorMode": "code",
           "expr": "sum(rate(omnistat_network_rx_bytes{device_class!=\"net\"}[$__rate_interval]) * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"}) + sum(rate(omnistat_network_tx_bytes{device_class!=\"net\"}[$__rate_interval]) * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-          "hide": false,
           "instant": false,
           "interval": "$interval",
           "legendFormat": "High Performance Interconnect",
@@ -1587,7 +1574,6 @@
               "mode": "off"
             }
           },
-          "mappings": [],
           "min": 0,
           "thresholds": {
             "mode": "absolute",
@@ -1646,6 +1632,10 @@
       "id": 119,
       "interval": "$interval",
       "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
         "legend": {
           "calcs": [],
           "displayMode": "list",
@@ -1659,7 +1649,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -1668,7 +1658,6 @@
           },
           "editorMode": "code",
           "expr": "sum(rate(omnistat_network_rx_bytes{device_class=\"net\"}[$__rate_interval]) * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-          "hide": false,
           "instant": false,
           "interval": "$interval",
           "legendFormat": "Eth Rx",
@@ -1682,7 +1671,6 @@
           },
           "editorMode": "code",
           "expr": "sum(rate(omnistat_network_tx_bytes{device_class=\"net\"}[$__rate_interval]) * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-          "hide": false,
           "instant": false,
           "interval": "$interval",
           "legendFormat": "Eth Tx",
@@ -1709,7 +1697,6 @@
           },
           "editorMode": "code",
           "expr": "sum(rate(omnistat_network_tx_bytes{device_class!=\"net\"}[$__rate_interval]) * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-          "hide": false,
           "instant": false,
           "interval": "$interval",
           "legendFormat": "Other Tx",
@@ -1717,6 +1704,7 @@
           "refId": "B"
         }
       ],
+      "title": "",
       "type": "timeseries"
     },
     {
@@ -1727,7 +1715,7 @@
         "x": 0,
         "y": 25
       },
-      "id": 82,
+      "id": 190,
       "panels": [
         {
           "datasource": {
@@ -1746,14 +1734,13 @@
                   "type": "linear"
                 }
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 836
+            "y": 26
           },
           "id": 88,
           "interval": "$interval",
@@ -1856,14 +1843,13 @@
                   "type": "linear"
                 }
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 836
+            "y": 26
           },
           "id": 89,
           "interval": "$interval",
@@ -1992,12 +1978,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2006,14 +1992,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 883
+            "y": 73
           },
           "id": 91,
           "interval": "$interval",
@@ -2089,15 +2074,14 @@
                   "mode": "off"
                 }
               },
-              "fieldMinMax": true,
-              "mappings": [],
               "max": 100,
               "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2164,7 +2148,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 891
+            "y": 81
           },
           "id": 99,
           "interval": "$interval",
@@ -2270,13 +2254,12 @@
                 },
                 "inspect": false
               },
-              "fieldMinMax": false,
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2328,7 +2311,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 891
+            "y": 81
           },
           "id": 100,
           "interval": "$interval",
@@ -2375,8 +2358,7 @@
                 "reducers": [
                   "mean"
                 ]
-              },
-              "topic": "series"
+              }
             },
             {
               "disabled": true,
@@ -2439,7 +2421,7 @@
         "x": 0,
         "y": 26
       },
-      "id": 15,
+      "id": 191,
       "panels": [
         {
           "datasource": {
@@ -2452,12 +2434,12 @@
                 "mode": "thresholds"
               },
               "decimals": 2,
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "#EAB839",
@@ -2470,14 +2452,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 3782
+            "y": 27
           },
           "id": 28,
           "interval": "$interval",
@@ -2532,14 +2513,13 @@
                   "type": "linear"
                 }
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 3782
+            "y": 27
           },
           "id": 86,
           "interval": "$interval",
@@ -2627,12 +2607,12 @@
                 "mode": "thresholds"
               },
               "decimals": 2,
-              "mappings": [],
               "thresholds": {
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "#EAB839",
@@ -2645,14 +2625,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 4168
+            "y": 413
           },
           "id": 29,
           "interval": "$interval",
@@ -2707,14 +2686,13 @@
                   "type": "linear"
                 }
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 4168
+            "y": 413
           },
           "id": 31,
           "interval": "$interval",
@@ -2834,12 +2812,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2848,14 +2826,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 4176
+            "y": 421
           },
           "id": 24,
           "interval": "$interval",
@@ -2903,7 +2880,7 @@
         "x": 0,
         "y": 27
       },
-      "id": 81,
+      "id": 192,
       "panels": [
         {
           "datasource": {
@@ -2922,14 +2899,13 @@
                   "type": "linear"
                 }
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 3783
+            "y": 28
           },
           "id": 27,
           "interval": "$interval",
@@ -3032,14 +3008,13 @@
                   "type": "linear"
                 }
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 3783
+            "y": 28
           },
           "id": 87,
           "interval": "$interval",
@@ -3168,12 +3143,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3182,14 +3157,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3794
+            "y": 39
           },
           "id": 90,
           "interval": "$interval",
@@ -3265,15 +3239,14 @@
                   "mode": "off"
                 }
               },
-              "fieldMinMax": true,
-              "mappings": [],
               "max": 100,
               "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3356,7 +3329,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 3802
+            "y": 47
           },
           "id": 98,
           "interval": "$interval",
@@ -3478,13 +3451,12 @@
                 },
                 "inspect": false
               },
-              "fieldMinMax": false,
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3536,7 +3508,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 3802
+            "y": 47
           },
           "id": 95,
           "interval": "$interval",
@@ -3583,8 +3555,7 @@
                 "reducers": [
                   "mean"
                 ]
-              },
-              "topic": "series"
+              }
             },
             {
               "id": "extractFields",
@@ -3678,12 +3649,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -3767,7 +3738,8 @@
                     "value": 0
                   },
                   {
-                    "id": "displayName"
+                    "id": "displayName",
+                    "value": null
                   },
                   {
                     "id": "color",
@@ -3807,7 +3779,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 3811
+            "y": 56
           },
           "id": 52,
           "interval": "$interval",
@@ -3846,7 +3818,6 @@
               },
               "editorMode": "code",
               "expr": "quantile(0.5, (rocm_utilization_percentage * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) ",
-              "hide": false,
               "instant": false,
               "legendFormat": "Median",
               "range": true,
@@ -3859,7 +3830,6 @@
               },
               "editorMode": "code",
               "expr": "quantile(0.8, (rocm_utilization_percentage * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) ",
-              "hide": false,
               "instant": false,
               "legendFormat": "Quantile 0.8",
               "range": true,
@@ -3872,7 +3842,6 @@
               },
               "editorMode": "code",
               "expr": "avg(rocm_utilization_percentage * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "instant": false,
               "legendFormat": "Average",
               "range": true,
@@ -3894,7 +3863,7 @@
         "x": 0,
         "y": 28
       },
-      "id": 126,
+      "id": 193,
       "panels": [
         {
           "datasource": {
@@ -3939,12 +3908,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3953,14 +3922,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2677
+            "y": 29
           },
           "id": 142,
           "interval": "$interval",
@@ -4048,12 +4016,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4062,14 +4030,13 @@
                 ]
               },
               "unit": "celsius"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3317
+            "y": 669
           },
           "id": 33,
           "interval": "$interval",
@@ -4157,12 +4124,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4171,14 +4138,13 @@
                 ]
               },
               "unit": "celsius"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3325
+            "y": 677
           },
           "id": 128,
           "interval": "$interval",
@@ -4266,12 +4232,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4280,14 +4246,13 @@
                 ]
               },
               "unit": "watt"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3333
+            "y": 685
           },
           "id": 129,
           "interval": "$interval",
@@ -4375,12 +4340,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4389,14 +4354,13 @@
                 ]
               },
               "unit": "rotmhz"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3341
+            "y": 693
           },
           "id": 130,
           "interval": "$interval",
@@ -4484,12 +4448,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4498,14 +4462,13 @@
                 ]
               },
               "unit": "rotmhz"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3341
+            "y": 693
           },
           "id": 131,
           "interval": "$interval",
@@ -4562,7 +4525,7 @@
         "x": 0,
         "y": 29
       },
-      "id": 21,
+      "id": 194,
       "panels": [
         {
           "datasource": {
@@ -4607,12 +4570,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4621,14 +4584,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 4187
+            "y": 30
           },
           "id": 143,
           "interval": "$interval",
@@ -4707,12 +4669,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4721,14 +4683,13 @@
                 ]
               },
               "unit": "celsius"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 4195
+            "y": 38
           },
           "id": 127,
           "interval": "$interval",
@@ -4807,12 +4768,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4821,14 +4782,13 @@
                 ]
               },
               "unit": "celsius"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 4203
+            "y": 46
           },
           "id": 104,
           "interval": "$interval",
@@ -4907,12 +4867,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4921,14 +4881,13 @@
                 ]
               },
               "unit": "watt"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 4211
+            "y": 54
           },
           "id": 22,
           "interval": "$interval",
@@ -5007,12 +4966,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5021,14 +4980,13 @@
                 ]
               },
               "unit": "rotmhz"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4219
+            "y": 62
           },
           "id": 25,
           "interval": "$interval",
@@ -5107,12 +5065,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5121,14 +5079,13 @@
                 ]
               },
               "unit": "rotmhz"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4219
+            "y": 62
           },
           "id": 23,
           "interval": "$interval",
@@ -5176,7 +5133,7 @@
         "x": 0,
         "y": 30
       },
-      "id": 136,
+      "id": 195,
       "panels": [
         {
           "datasource": {
@@ -5221,12 +5178,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5235,14 +5192,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3607
+            "y": 31
           },
           "id": 144,
           "interval": "$interval",
@@ -5330,12 +5286,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5344,14 +5300,13 @@
                 ]
               },
               "unit": "celsius"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3687
+            "y": 111
           },
           "id": 137,
           "interval": "$interval",
@@ -5439,12 +5394,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5453,14 +5408,13 @@
                 ]
               },
               "unit": "celsius"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3695
+            "y": 119
           },
           "id": 138,
           "interval": "$interval",
@@ -5548,12 +5502,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5562,14 +5516,13 @@
                 ]
               },
               "unit": "watt"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3703
+            "y": 127
           },
           "id": 139,
           "interval": "$interval",
@@ -5657,12 +5610,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5671,14 +5624,13 @@
                 ]
               },
               "unit": "rotmhz"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3711
+            "y": 135
           },
           "id": 140,
           "interval": "$interval",
@@ -5766,12 +5718,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5780,14 +5732,13 @@
                 ]
               },
               "unit": "rotmhz"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3711
+            "y": 135
           },
           "id": 141,
           "interval": "$interval",
@@ -5844,7 +5795,7 @@
         "x": 0,
         "y": 31
       },
-      "id": 123,
+      "id": 196,
       "panels": [
         {
           "datasource": {
@@ -5890,7 +5841,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -5905,14 +5855,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2186
+            "y": 32
           },
           "id": 134,
           "interval": "$interval",
@@ -5969,14 +5918,13 @@
         "x": 0,
         "y": 32
       },
-      "id": 157,
+      "id": 197,
       "panels": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${source}"
           },
-          "description": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -6015,7 +5963,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6030,14 +5977,13 @@
                 ]
               },
               "unit": "KBs"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2366
+            "y": 33
           },
           "id": 156,
           "interval": "$interval",
@@ -6088,7 +6034,6 @@
             "type": "prometheus",
             "uid": "${source}"
           },
-          "description": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -6127,7 +6072,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6142,14 +6086,13 @@
                 ]
               },
               "unit": "KBs"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2366
+            "y": 33
           },
           "id": 158,
           "interval": "$interval",
@@ -6207,7 +6150,7 @@
         "x": 0,
         "y": 33
       },
-      "id": 150,
+      "id": 198,
       "panels": [
         {
           "datasource": {
@@ -6253,12 +6196,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6267,14 +6210,13 @@
                 ]
               },
               "unit": "sci"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2713
+            "y": 34
           },
           "id": 151,
           "interval": "$interval",
@@ -6335,7 +6277,7 @@
         "x": 0,
         "y": 34
       },
-      "id": 133,
+      "id": 199,
       "panels": [
         {
           "datasource": {
@@ -6382,7 +6324,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6397,14 +6338,13 @@
                 ]
               },
               "unit": "cps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1453
+            "y": 35
           },
           "id": 125,
           "interval": "$interval",
@@ -6465,7 +6405,7 @@
         "x": 0,
         "y": 35
       },
-      "id": 152,
+      "id": 200,
       "panels": [
         {
           "datasource": {
@@ -6512,7 +6452,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6527,18 +6466,16 @@
                 ]
               },
               "unit": "KBs"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1454
+            "y": 36
           },
           "id": 153,
           "interval": "$interval",
-          "maxPerRow": 2,
           "options": {
             "legend": {
               "calcs": [],
@@ -6626,7 +6563,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6641,18 +6577,16 @@
                 ]
               },
               "unit": "KBs"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1454
+            "y": 36
           },
           "id": 154,
           "interval": "$interval",
-          "maxPerRow": 2,
           "options": {
             "legend": {
               "calcs": [],
@@ -6740,7 +6674,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6755,18 +6688,16 @@
                 ]
               },
               "unit": "flops"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1742
+            "y": 324
           },
           "id": 155,
           "interval": "$interval",
-          "maxPerRow": 2,
           "options": {
             "legend": {
               "calcs": [],
@@ -6854,7 +6785,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6869,14 +6799,13 @@
                 ]
               },
               "unit": "flops"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1750
+            "y": 332
           },
           "id": 165,
           "interval": "$interval",
@@ -6960,7 +6889,6 @@
               },
               "max": 100,
               "min": 0,
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6975,18 +6903,16 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1842
+            "y": 424
           },
           "id": 186,
           "interval": "$interval",
-          "maxPerRow": 2,
           "options": {
             "legend": {
               "calcs": [],
@@ -7076,7 +7002,6 @@
               },
               "max": 100,
               "min": 0,
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7091,18 +7016,16 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1842
+            "y": 424
           },
           "id": 187,
           "interval": "$interval",
-          "maxPerRow": 2,
           "options": {
             "legend": {
               "calcs": [],
@@ -7157,7 +7080,7 @@
         "x": 0,
         "y": 36
       },
-      "id": 168,
+      "id": 201,
       "panels": [
         {
           "datasource": {
@@ -7170,7 +7093,6 @@
               "color": {
                 "mode": "thresholds"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7185,14 +7107,13 @@
                 ]
               },
               "unit": "none"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
-            "h": 2,
+            "h": 3,
             "w": 8,
             "x": 0,
-            "y": 847
+            "y": 37
           },
           "id": 174,
           "interval": "$interval",
@@ -7213,7 +7134,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "12.3.1",
+          "pluginVersion": "13.0.1",
           "targets": [
             {
               "datasource": {
@@ -7243,7 +7164,6 @@
               "color": {
                 "mode": "thresholds"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7258,14 +7178,13 @@
                 ]
               },
               "unit": "none"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
-            "h": 2,
+            "h": 3,
             "w": 8,
             "x": 8,
-            "y": 847
+            "y": 37
           },
           "id": 175,
           "interval": "$interval",
@@ -7286,7 +7205,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "12.3.1",
+          "pluginVersion": "13.0.1",
           "targets": [
             {
               "datasource": {
@@ -7316,7 +7235,6 @@
               "color": {
                 "mode": "thresholds"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7331,14 +7249,13 @@
                 ]
               },
               "unit": "none"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
-            "h": 2,
+            "h": 3,
             "w": 8,
             "x": 16,
-            "y": 847
+            "y": 37
           },
           "id": 176,
           "interval": "$interval",
@@ -7359,7 +7276,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "12.3.1",
+          "pluginVersion": "13.0.1",
           "targets": [
             {
               "datasource": {
@@ -7399,7 +7316,6 @@
                 },
                 "inspect": false
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7427,6 +7343,52 @@
                     "value": "none"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Min"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "from": 1000000000000000,
+                          "result": {
+                            "index": 0,
+                            "text": "-"
+                          }
+                        },
+                        "type": "range"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Max"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "from": 1000000000000000,
+                          "result": {
+                            "index": 0,
+                            "text": "-"
+                          }
+                        },
+                        "type": "range"
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           },
@@ -7434,7 +7396,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 849
+            "y": 40
           },
           "id": 169,
           "interval": "$interval",
@@ -7442,7 +7404,7 @@
             "cellHeight": "sm",
             "showHeader": true
           },
-          "pluginVersion": "12.3.1",
+          "pluginVersion": "13.0.1",
           "targets": [
             {
               "datasource": {
@@ -7467,7 +7429,6 @@
               "exemplar": false,
               "expr": "sum by (kernel) (increase(omnistat_kernel_total_duration_ns[$__range]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"}))",
               "format": "table",
-              "hide": false,
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -7482,7 +7443,6 @@
               "exemplar": false,
               "expr": "sum by (kernel) (increase(omnistat_kernel_dispatch_count[$__range]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"}))",
               "format": "table",
-              "hide": false,
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -7497,7 +7457,6 @@
               "exemplar": false,
               "expr": "sum by (kernel) (increase(omnistat_kernel_total_duration_ns[$__range]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"})) / sum by (kernel) (increase(omnistat_kernel_dispatch_count[$__range]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"}))",
               "format": "table",
-              "hide": false,
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -7558,6 +7517,15 @@
                       }
                     },
                     "fieldName": "Value #B (sum)"
+                  },
+                  {
+                    "config": {
+                      "id": "greater",
+                      "options": {
+                        "value": 0
+                      }
+                    },
+                    "fieldName": "Value #C (sum)"
                   }
                 ],
                 "match": "all",
@@ -7646,7 +7614,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7661,18 +7628,21 @@
                 ]
               },
               "unit": "ns"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 857
+            "y": 48
           },
           "id": 170,
           "interval": "$interval",
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [],
               "displayMode": "list",
@@ -7685,7 +7655,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.3.1",
+          "pluginVersion": "13.0.1",
           "targets": [
             {
               "datasource": {
@@ -7693,7 +7663,7 @@
                 "uid": "${source}"
               },
               "editorMode": "code",
-              "expr": "avg by (kernel) ((increase(omnistat_kernel_total_duration_ns{kernel=~\"$top_kernels\"}[$__rate_interval]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"})) / (increase(omnistat_kernel_dispatch_count{kernel=~\"$top_kernels\"}[$__rate_interval]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"})))",
+              "expr": "(avg by (kernel) ((increase(omnistat_kernel_total_duration_ns{kernel=~\"$top_kernels\"}[$__rate_interval]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"})) / (increase(omnistat_kernel_dispatch_count{kernel=~\"$top_kernels\"}[$__rate_interval]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"})))) > 0",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -7714,7 +7684,7 @@
         "x": 0,
         "y": 37
       },
-      "id": 171,
+      "id": 202,
       "panels": [
         {
           "datasource": {
@@ -7760,7 +7730,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7775,18 +7744,21 @@
                 ]
               },
               "unit": "ns"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1456
+            "y": 38
           },
           "id": 172,
           "interval": "$interval",
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [],
               "displayMode": "list",
@@ -7799,7 +7771,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.3.1",
+          "pluginVersion": "13.0.1",
           "repeat": "top_kernels",
           "repeatDirection": "v",
           "targets": [
@@ -7809,7 +7781,7 @@
                 "uid": "${source}"
               },
               "editorMode": "code",
-              "expr": "avg by (instance,card) ((increase(omnistat_kernel_total_duration_ns{kernel=\"$top_kernels\"}[$__rate_interval]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"})) / (increase(omnistat_kernel_dispatch_count{kernel=\"$top_kernels\"}[$__rate_interval]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"})))",
+              "expr": "(avg by (instance,card) ((increase(omnistat_kernel_total_duration_ns{kernel=\"$top_kernels\"}[$__rate_interval]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"})) / (increase(omnistat_kernel_dispatch_count{kernel=\"$top_kernels\"}[$__rate_interval]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"})))) > 0",
               "legendFormat": "GPU: {{instance}}/{{card}}",
               "range": true,
               "refId": "A"
@@ -7838,7 +7810,6 @@
                 },
                 "inspect": false
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7885,7 +7856,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1456
+            "y": 38
           },
           "id": 173,
           "interval": "$interval",
@@ -7893,7 +7864,7 @@
             "cellHeight": "sm",
             "showHeader": true
           },
-          "pluginVersion": "12.3.1",
+          "pluginVersion": "13.0.1",
           "repeat": "top_kernels",
           "repeatDirection": "v",
           "targets": [
@@ -7920,7 +7891,6 @@
               "exemplar": false,
               "expr": "sum by (instance,card) (increase(omnistat_kernel_total_duration_ns{kernel=\"$top_kernels\"}[$__range]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"}))",
               "format": "table",
-              "hide": false,
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -7935,7 +7905,6 @@
               "exemplar": false,
               "expr": "sum by (instance,card) (increase(omnistat_kernel_dispatch_count{kernel=\"$top_kernels\"}[$__range]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"}))",
               "format": "table",
-              "hide": false,
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -8033,7 +8002,7 @@
         "x": 0,
         "y": 38
       },
-      "id": 44,
+      "id": 203,
       "panels": [
         {
           "datasource": {
@@ -8078,7 +8047,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -8093,14 +8061,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2188
+            "y": 39
           },
           "id": 43,
           "interval": "$interval",
@@ -8188,7 +8155,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -8203,14 +8169,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2188
+            "y": 39
           },
           "id": 48,
           "interval": "$interval",
@@ -8267,7 +8232,7 @@
         "x": 0,
         "y": 39
       },
-      "id": 122,
+      "id": 204,
       "panels": [
         {
           "datasource": {
@@ -8315,7 +8280,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -8329,14 +8293,13 @@
                   }
                 ]
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1947
+            "y": 40
           },
           "id": 120,
           "options": {
@@ -8378,7 +8341,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_sdma_correctable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "SDMA, {{instance}}, {{card}}",
               "range": true,
@@ -8392,7 +8354,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_gfx_correctable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "GFX, {{instance}}, {{card}}",
               "range": true,
@@ -8406,7 +8367,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_mmhub_correctable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "MMHUB, {{instance}}, {{card}}",
               "range": true,
@@ -8420,7 +8380,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_pcie_bif_correctable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "PCIE BIF, {{instance}}, {{card}}",
               "range": true,
@@ -8434,7 +8393,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_hdp_correctable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "HDP, {{instance}}, {{card}}",
               "range": true,
@@ -8448,7 +8406,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_xgmi_wafl_correctable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "XGMI WAFL, {{instance}}, {{card}}",
               "range": true,
@@ -8513,7 +8470,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -8527,14 +8483,13 @@
                   }
                 ]
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1947
+            "y": 40
           },
           "id": 121,
           "options": {
@@ -8576,7 +8531,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_sdma_uncorrectable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "SDMA, {{instance}}, {{card}}",
               "range": true,
@@ -8590,7 +8544,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_gfx_uncorrectable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "GFX, {{instance}}, {{card}}",
               "range": true,
@@ -8604,7 +8557,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_mmhub_uncorrectable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "MMHUB, {{instance}}, {{card}}",
               "range": true,
@@ -8618,7 +8570,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_pcie_bif_uncorrectable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "PCIE BIF, {{instance}}, {{card}}",
               "range": true,
@@ -8632,7 +8583,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_hdp_uncorrectable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "HDP, {{instance}}, {{card}}",
               "range": true,
@@ -8646,7 +8596,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_xgmi_wafl_uncorrectable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "XGMI WAFL, {{instance}}, {{card}}",
               "range": true,
@@ -8677,7 +8626,7 @@
         "x": 0,
         "y": 40
       },
-      "id": 101,
+      "id": 205,
       "panels": [
         {
           "datasource": {
@@ -8722,7 +8671,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -8737,14 +8685,13 @@
                 ]
               },
               "unit": "binBps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2260
+            "y": 41
           },
           "id": 105,
           "interval": "$interval",
@@ -8833,7 +8780,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -8848,14 +8794,13 @@
                 ]
               },
               "unit": "binBps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2260
+            "y": 41
           },
           "id": 106,
           "interval": "$interval",
@@ -8913,7 +8858,7 @@
         "x": 0,
         "y": 41
       },
-      "id": 41,
+      "id": 206,
       "panels": [
         {
           "datasource": {
@@ -8958,7 +8903,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -8973,14 +8917,13 @@
                 ]
               },
               "unit": "binBps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2261
+            "y": 42
           },
           "id": 116,
           "interval": "$interval",
@@ -9069,7 +9012,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -9084,14 +9026,13 @@
                 ]
               },
               "unit": "binBps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2261
+            "y": 42
           },
           "id": 117,
           "interval": "$interval",
@@ -9149,7 +9090,7 @@
         "x": 0,
         "y": 42
       },
-      "id": 83,
+      "id": 207,
       "panels": [
         {
           "datasource": {
@@ -9195,7 +9136,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -9210,14 +9150,13 @@
                 ]
               },
               "unit": "binBps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2032
+            "y": 43
           },
           "id": 46,
           "interval": "$interval",
@@ -9307,7 +9246,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -9322,14 +9260,13 @@
                 ]
               },
               "unit": "binBps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2032
+            "y": 43
           },
           "id": 45,
           "interval": "$interval",
@@ -9420,7 +9357,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -9435,14 +9371,13 @@
                 ]
               },
               "unit": "binBps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2040
+            "y": 51
           },
           "id": 159,
           "interval": "$interval",
@@ -9533,7 +9468,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -9548,14 +9482,13 @@
                 ]
               },
               "unit": "binBps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2040
+            "y": 51
           },
           "id": 160,
           "interval": "$interval",
@@ -9612,7 +9545,6 @@
               "color": {
                 "mode": "fixed"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -9623,14 +9555,13 @@
                 ]
               },
               "unit": "bytes"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 3,
             "w": 12,
             "x": 0,
-            "y": 2048
+            "y": 59
           },
           "id": 161,
           "interval": "$interval",
@@ -9689,7 +9620,6 @@
               "color": {
                 "mode": "fixed"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -9700,14 +9630,13 @@
                 ]
               },
               "unit": "bytes"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 3,
             "w": 12,
             "x": 12,
-            "y": 2048
+            "y": 59
           },
           "id": 162,
           "interval": "$interval",
@@ -9767,7 +9696,7 @@
         "x": 0,
         "y": 44
       },
-      "id": 132,
+      "id": 209,
       "panels": [
         {
           "datasource": {
@@ -9813,12 +9742,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -9827,14 +9756,13 @@
                 ]
               },
               "unit": "none"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 6424
+            "y": 45
           },
           "id": 135,
           "interval": "$interval",
@@ -9893,7 +9821,7 @@
         "x": 0,
         "y": 45
       },
-      "id": 57,
+      "id": 210,
       "panels": [
         {
           "datasource": {
@@ -9912,12 +9840,12 @@
                 },
                 "inspect": false
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -9998,7 +9926,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 6473
+            "y": 46
           },
           "id": 56,
           "interval": "$interval",
@@ -10036,7 +9964,6 @@
               },
               "editorMode": "code",
               "expr": "avg by (marker) (avg by (instance) (rocm_utilization_percentage) * on (instance) group_left(jobid,marker) rmsjob_info{jobid=\"$jobid\"} * on (jobid) group_left(marker) count by (jobid,marker) (rmsjob_annotations{jobid=\"$jobid\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -10059,8 +9986,7 @@
                   "last",
                   "range"
                 ]
-              },
-              "topic": "series"
+              }
             },
             {
               "filter": {
@@ -10093,7 +10019,7 @@
         "x": 0,
         "y": 46
       },
-      "id": 111,
+      "id": 211,
       "panels": [
         {
           "datasource": {
@@ -10115,7 +10041,6 @@
                 },
                 "inspect": false
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -10244,7 +10169,6 @@
               },
               "editorMode": "code",
               "expr": "timestamp(count by (jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))*1000",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -10257,7 +10181,6 @@
               },
               "editorMode": "code",
               "expr": "count by (jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0)",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -10281,8 +10204,7 @@
                   "last",
                   "range"
                 ]
-              },
-              "topic": "series"
+              }
             },
             {
               "filter": {
@@ -10359,7 +10281,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -10494,7 +10415,6 @@
                 },
                 "inspect": false
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -10595,7 +10515,6 @@
               },
               "editorMode": "code",
               "expr": "avg by (jobstep) ((rocm_utilization_percentage) * on (instance) group_left(jobid,jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -10608,7 +10527,6 @@
               },
               "editorMode": "code",
               "expr": "max by (jobstep) ((rocm_utilization_percentage) * on (instance) group_left(jobid,jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -10621,7 +10539,6 @@
               },
               "editorMode": "code",
               "expr": "timestamp(count by (jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -10641,8 +10558,7 @@
                 "reducers": [
                   "mean"
                 ]
-              },
-              "topic": "series"
+              }
             },
             {
               "filter": {
@@ -10727,7 +10643,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -10874,7 +10789,6 @@
                 },
                 "inspect": false
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -10975,7 +10889,6 @@
               },
               "editorMode": "code",
               "expr": "avg by (jobstep) ((rocm_vram_used_percentage) * on (instance) group_left(jobid,jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -10988,7 +10901,6 @@
               },
               "editorMode": "code",
               "expr": "max by (jobstep) ((rocm_vram_used_percentage) * on (instance) group_left(jobid,jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -11001,7 +10913,6 @@
               },
               "editorMode": "code",
               "expr": "timestamp(count by (jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -11021,8 +10932,7 @@
                 "reducers": [
                   "mean"
                 ]
-              },
-              "topic": "series"
+              }
             },
             {
               "filter": {
@@ -11107,7 +11017,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -11239,7 +11148,6 @@
             "type": "prometheus",
             "uid": "$source"
           },
-          "description": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -11252,12 +11160,12 @@
                 },
                 "inspect": false
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -11360,7 +11268,6 @@
               },
               "editorMode": "code",
               "expr": "avg by (jobstep) ((rocm_average_socket_power_watts) * on (instance) group_left(jobid,jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -11373,7 +11280,6 @@
               },
               "editorMode": "code",
               "expr": "max by (jobstep) ((rocm_average_socket_power_watts) * on (instance) group_left(jobid,jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -11386,7 +11292,6 @@
               },
               "editorMode": "code",
               "expr": "timestamp(count by (jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -11406,8 +11311,7 @@
                 "reducers": [
                   "mean"
                 ]
-              },
-              "topic": "series"
+              }
             },
             {
               "filter": {
@@ -11492,12 +11396,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -11626,7 +11530,7 @@
         "x": 0,
         "y": 47
       },
-      "id": 177,
+      "id": 212,
       "panels": [
         {
           "datasource": {
@@ -11638,7 +11542,6 @@
               "color": {
                 "mode": "fixed"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -11648,8 +11551,7 @@
                   }
                 ]
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 2,
@@ -11706,7 +11608,6 @@
               "color": {
                 "mode": "fixed"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -11716,8 +11617,7 @@
                   }
                 ]
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 2,
@@ -11774,7 +11674,6 @@
               "color": {
                 "mode": "fixed"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -11784,8 +11683,7 @@
                   }
                 ]
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 2,
@@ -11842,7 +11740,6 @@
               "color": {
                 "mode": "fixed"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -11853,8 +11750,7 @@
                 ]
               },
               "unit": "s"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 2,
@@ -11911,7 +11807,6 @@
               "color": {
                 "mode": "fixed"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -11922,8 +11817,7 @@
                 ]
               },
               "unit": "s"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 2,
@@ -12014,7 +11908,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -12029,8 +11922,7 @@
                 ]
               },
               "unit": "s"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
@@ -12062,7 +11954,6 @@
               },
               "editorMode": "code",
               "expr": "avg by (collector) (omnistat_perf_runtime_seconds{collector=\"total\"} * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "instant": false,
               "legendFormat": "Total [average]",
               "range": true,
@@ -12075,7 +11966,6 @@
               },
               "editorMode": "code",
               "expr": "max by (collector) (omnistat_perf_runtime_seconds{collector=\"total\"} * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "instant": false,
               "legendFormat": "Total [max]",
               "range": true,
@@ -12088,7 +11978,6 @@
               },
               "editorMode": "code",
               "expr": "avg by (collector) (omnistat_perf_runtime_seconds{collector!=\"total\"} * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "instant": false,
               "legendFormat": "Collector: {{collector}} [average]",
               "range": true,
@@ -12101,7 +11990,6 @@
               },
               "editorMode": "code",
               "expr": "max by (collector) (omnistat_perf_runtime_seconds{collector!=\"total\"} * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "instant": false,
               "legendFormat": "Collector: {{collector}} [max]",
               "range": true,
@@ -12155,7 +12043,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -12170,8 +12057,7 @@
                 ]
               },
               "unit": "s"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
@@ -12203,7 +12089,6 @@
               },
               "editorMode": "code",
               "expr": "avg(omnistat_perf_push_seconds * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "instant": false,
               "legendFormat": "Push [average]",
               "range": true,
@@ -12216,7 +12101,6 @@
               },
               "editorMode": "code",
               "expr": "avg(omnistat_perf_push_seconds * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "instant": false,
               "interval": "",
               "legendFormat": "Push [max]",
@@ -12241,7 +12125,6 @@
               },
               "editorMode": "code",
               "expr": "max(omnistat_perf_push_background_seconds * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "legendFormat": "Background Push [max]",
               "range": true,
               "refId": "Background Max"
@@ -12258,28 +12141,32 @@
   "preload": false,
   "refresh": "",
   "schemaVersion": 42,
-  "tags": [],
   "templating": {
     "list": [
       {
         "allowCustomValue": false,
         "hide": 2,
         "includeAll": false,
+        "multi": false,
         "name": "source",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "type": "datasource"
       },
       {
+        "allowCustomValue": true,
         "datasource": {
           "type": "prometheus",
           "uid": "${source}"
         },
         "definition": "label_values(rmsjob_info,jobid)",
+        "hide": 0,
         "includeAll": false,
         "label": "Job ID",
+        "multi": false,
         "name": "jobid",
         "options": [],
         "query": {
@@ -12289,16 +12176,21 @@
         },
         "refresh": 1,
         "regex": "",
-        "sort": 8,
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": 0,
         "type": "query"
       },
       {
+        "allowCustomValue": true,
         "current": {
           "text": "1s",
           "value": "1s"
         },
+        "hide": 0,
         "includeAll": false,
         "label": "Resolution",
+        "multi": false,
         "name": "interval",
         "options": [
           {
@@ -12338,7 +12230,9 @@
           }
         ],
         "query": "0.1s,0.5s,1s,5s,15s,30s,60s",
-        "type": "custom"
+        "skipUrlSync": false,
+        "type": "custom",
+        "valuesFormat": "csv"
       },
       {
         "allowCustomValue": false,
@@ -12350,6 +12244,7 @@
         "hide": 2,
         "includeAll": false,
         "label": "Sampling interval",
+        "multi": false,
         "name": "sampling_interval",
         "options": [],
         "query": {
@@ -12359,6 +12254,9 @@
         },
         "refresh": 2,
         "regex": "/interval_secs=\"([^\"]*)\"/",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": 0,
         "type": "query"
       },
       {
@@ -12385,6 +12283,8 @@
         },
         "refresh": 2,
         "regex": "/.*name=\"([^\"]*).*/",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
         "sort": 1,
         "type": "query"
       },
@@ -12412,6 +12312,8 @@
         },
         "refresh": 2,
         "regex": "/.*name=\"([^\"]*).*/",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
         "sort": 1,
         "type": "query"
       },
@@ -12439,6 +12341,9 @@
         },
         "refresh": 2,
         "regex": "/.*kernel=\"([^\"]*).*/",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": 0,
         "type": "query"
       }
     ]
@@ -12448,9 +12353,8 @@
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "",
+  "timezone": "browser",
   "title": "Job - User",
   "uid": "fdqo0h2s2drswe-user",
-  "version": 1,
-  "weekStart": ""
+  "version": 1
 }

--- a/grafana/json-models/system/rms-job.json
+++ b/grafana/json-models/system/rms-job.json
@@ -55,8 +55,7 @@
         "x": 0,
         "y": 0
       },
-      "id": 35,
-      "panels": [],
+      "id": 188,
       "title": "Job Info",
       "type": "row"
     },
@@ -70,7 +69,6 @@
           "color": {
             "mode": "fixed"
           },
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -80,8 +78,7 @@
               }
             ]
           }
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 3,
@@ -110,7 +107,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -140,7 +137,6 @@
           "color": {
             "mode": "fixed"
           },
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -150,8 +146,7 @@
               }
             ]
           }
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 3,
@@ -180,7 +175,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -214,7 +209,6 @@
           "color": {
             "mode": "fixed"
           },
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -224,8 +218,7 @@
               }
             ]
           }
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 3,
@@ -254,7 +247,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -312,8 +305,7 @@
               }
             ]
           }
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 3,
@@ -342,7 +334,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -386,7 +378,6 @@
           "color": {
             "mode": "fixed"
           },
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -396,8 +387,7 @@
               }
             ]
           }
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 3,
@@ -426,7 +416,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -455,7 +445,6 @@
           "color": {
             "mode": "fixed"
           },
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -465,8 +454,7 @@
               }
             ]
           }
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 3,
@@ -495,7 +483,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -523,7 +511,6 @@
           "color": {
             "mode": "fixed"
           },
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -534,8 +521,7 @@
             ]
           },
           "unit": "dthms"
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 3,
@@ -564,7 +550,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -573,7 +559,6 @@
           },
           "editorMode": "code",
           "expr": "max(timestamp(rmsjob_info{jobid=\"$jobid\"}))",
-          "hide": false,
           "instant": false,
           "interval": "",
           "legendFormat": "__auto",
@@ -592,8 +577,7 @@
         "x": 0,
         "y": 4
       },
-      "id": 66,
-      "panels": [],
+      "id": 189,
       "title": "Performance Overview",
       "type": "row"
     },
@@ -609,7 +593,6 @@
             "mode": "thresholds"
           },
           "decimals": 0,
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -628,8 +611,7 @@
             ]
           },
           "unit": "percent"
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 4,
@@ -655,7 +637,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -721,7 +703,6 @@
               "mode": "off"
             }
           },
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -788,6 +769,10 @@
       "id": 58,
       "interval": "$interval",
       "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
         "legend": {
           "calcs": [],
           "displayMode": "list",
@@ -801,7 +786,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -822,13 +807,13 @@
           },
           "editorMode": "code",
           "expr": "max(rocm_utilization_percentage * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-          "hide": false,
           "instant": false,
           "legendFormat": "Max",
           "range": true,
           "refId": "B"
         }
       ],
+      "title": "",
       "type": "timeseries"
     },
     {
@@ -843,7 +828,6 @@
             "mode": "thresholds"
           },
           "decimals": 0,
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -862,8 +846,7 @@
             ]
           },
           "unit": "percent"
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 4,
@@ -889,7 +872,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -955,7 +938,6 @@
               "mode": "off"
             }
           },
-          "mappings": [],
           "max": 100,
           "min": 0,
           "thresholds": {
@@ -1024,6 +1006,10 @@
       "id": 61,
       "interval": "$interval",
       "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
         "legend": {
           "calcs": [],
           "displayMode": "list",
@@ -1037,7 +1023,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -1058,13 +1044,13 @@
           },
           "editorMode": "code",
           "expr": "max(rocm_vram_used_percentage * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-          "hide": false,
           "instant": false,
           "legendFormat": "Max",
           "range": true,
           "refId": "B"
         }
       ],
+      "title": "",
       "type": "timeseries"
     },
     {
@@ -1079,7 +1065,6 @@
             "mode": "fixed"
           },
           "decimals": 0,
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1098,8 +1083,7 @@
             ]
           },
           "unit": "percent"
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 4,
@@ -1125,7 +1109,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -1189,7 +1173,6 @@
               "mode": "off"
             }
           },
-          "mappings": [],
           "min": 0,
           "thresholds": {
             "mode": "absolute",
@@ -1233,6 +1216,10 @@
       "id": 63,
       "interval": "$interval",
       "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
         "legend": {
           "calcs": [],
           "displayMode": "list",
@@ -1246,7 +1233,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -1261,6 +1248,7 @@
           "refId": "A"
         }
       ],
+      "title": "",
       "type": "timeseries"
     },
     {
@@ -1275,7 +1263,6 @@
             "mode": "thresholds"
           },
           "decimals": 0,
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1294,8 +1281,7 @@
             ]
           },
           "unit": "percent"
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 4,
@@ -1321,7 +1307,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -1387,7 +1373,6 @@
               "mode": "off"
             }
           },
-          "mappings": [],
           "max": 100,
           "min": 0,
           "thresholds": {
@@ -1432,6 +1417,10 @@
       "id": 65,
       "interval": "$interval",
       "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
         "legend": {
           "calcs": [],
           "displayMode": "list",
@@ -1445,7 +1434,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -1460,6 +1449,7 @@
           "refId": "A"
         }
       ],
+      "title": "",
       "type": "timeseries"
     },
     {
@@ -1474,7 +1464,6 @@
             "mode": "fixed"
           },
           "decimals": 0,
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1493,8 +1482,7 @@
             ]
           },
           "unit": "binBps"
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 4,
@@ -1521,7 +1509,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -1543,7 +1531,6 @@
           },
           "editorMode": "code",
           "expr": "sum(rate(omnistat_network_rx_bytes{device_class!=\"net\"}[$__rate_interval]) * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"}) + sum(rate(omnistat_network_tx_bytes{device_class!=\"net\"}[$__rate_interval]) * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-          "hide": false,
           "instant": false,
           "interval": "$interval",
           "legendFormat": "High Performance Interconnect",
@@ -1600,7 +1587,6 @@
               "mode": "off"
             }
           },
-          "mappings": [],
           "min": 0,
           "thresholds": {
             "mode": "absolute",
@@ -1659,6 +1645,10 @@
       "id": 119,
       "interval": "$interval",
       "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
         "legend": {
           "calcs": [],
           "displayMode": "list",
@@ -1672,7 +1662,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -1681,7 +1671,6 @@
           },
           "editorMode": "code",
           "expr": "sum(rate(omnistat_network_rx_bytes{device_class=\"net\"}[$__rate_interval]) * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-          "hide": false,
           "instant": false,
           "interval": "$interval",
           "legendFormat": "Eth Rx",
@@ -1695,7 +1684,6 @@
           },
           "editorMode": "code",
           "expr": "sum(rate(omnistat_network_tx_bytes{device_class=\"net\"}[$__rate_interval]) * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-          "hide": false,
           "instant": false,
           "interval": "$interval",
           "legendFormat": "Eth Tx",
@@ -1722,7 +1710,6 @@
           },
           "editorMode": "code",
           "expr": "sum(rate(omnistat_network_tx_bytes{device_class!=\"net\"}[$__rate_interval]) * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-          "hide": false,
           "instant": false,
           "interval": "$interval",
           "legendFormat": "Other Tx",
@@ -1730,6 +1717,7 @@
           "refId": "B"
         }
       ],
+      "title": "",
       "type": "timeseries"
     },
     {
@@ -1740,7 +1728,7 @@
         "x": 0,
         "y": 25
       },
-      "id": 82,
+      "id": 190,
       "panels": [
         {
           "datasource": {
@@ -1759,14 +1747,13 @@
                   "type": "linear"
                 }
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 836
+            "y": 26
           },
           "id": 88,
           "interval": "$interval",
@@ -1869,14 +1856,13 @@
                   "type": "linear"
                 }
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 836
+            "y": 26
           },
           "id": 89,
           "interval": "$interval",
@@ -2005,12 +1991,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2019,14 +2005,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 883
+            "y": 73
           },
           "id": 91,
           "interval": "$interval",
@@ -2102,15 +2087,14 @@
                   "mode": "off"
                 }
               },
-              "fieldMinMax": true,
-              "mappings": [],
               "max": 100,
               "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2177,7 +2161,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 891
+            "y": 81
           },
           "id": 99,
           "interval": "$interval",
@@ -2283,13 +2267,12 @@
                 },
                 "inspect": false
               },
-              "fieldMinMax": false,
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2341,7 +2324,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 891
+            "y": 81
           },
           "id": 100,
           "interval": "$interval",
@@ -2388,8 +2371,7 @@
                 "reducers": [
                   "mean"
                 ]
-              },
-              "topic": "series"
+              }
             },
             {
               "disabled": true,
@@ -2452,7 +2434,7 @@
         "x": 0,
         "y": 26
       },
-      "id": 15,
+      "id": 191,
       "panels": [
         {
           "datasource": {
@@ -2465,12 +2447,12 @@
                 "mode": "thresholds"
               },
               "decimals": 2,
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "#EAB839",
@@ -2483,14 +2465,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 3782
+            "y": 27
           },
           "id": 28,
           "interval": "$interval",
@@ -2545,14 +2526,13 @@
                   "type": "linear"
                 }
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 3782
+            "y": 27
           },
           "id": 86,
           "interval": "$interval",
@@ -2640,12 +2620,12 @@
                 "mode": "thresholds"
               },
               "decimals": 2,
-              "mappings": [],
               "thresholds": {
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "#EAB839",
@@ -2658,14 +2638,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 4168
+            "y": 413
           },
           "id": 29,
           "interval": "$interval",
@@ -2720,14 +2699,13 @@
                   "type": "linear"
                 }
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 4168
+            "y": 413
           },
           "id": 31,
           "interval": "$interval",
@@ -2847,12 +2825,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2861,14 +2839,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 4176
+            "y": 421
           },
           "id": 24,
           "interval": "$interval",
@@ -2916,7 +2893,7 @@
         "x": 0,
         "y": 27
       },
-      "id": 81,
+      "id": 192,
       "panels": [
         {
           "datasource": {
@@ -2935,14 +2912,13 @@
                   "type": "linear"
                 }
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 3783
+            "y": 28
           },
           "id": 27,
           "interval": "$interval",
@@ -3045,14 +3021,13 @@
                   "type": "linear"
                 }
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 3783
+            "y": 28
           },
           "id": 87,
           "interval": "$interval",
@@ -3181,12 +3156,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3195,14 +3170,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3794
+            "y": 39
           },
           "id": 90,
           "interval": "$interval",
@@ -3278,15 +3252,14 @@
                   "mode": "off"
                 }
               },
-              "fieldMinMax": true,
-              "mappings": [],
               "max": 100,
               "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3369,7 +3342,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 3802
+            "y": 47
           },
           "id": 98,
           "interval": "$interval",
@@ -3491,13 +3464,12 @@
                 },
                 "inspect": false
               },
-              "fieldMinMax": false,
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3549,7 +3521,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 3802
+            "y": 47
           },
           "id": 95,
           "interval": "$interval",
@@ -3596,8 +3568,7 @@
                 "reducers": [
                   "mean"
                 ]
-              },
-              "topic": "series"
+              }
             },
             {
               "id": "extractFields",
@@ -3691,12 +3662,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -3780,7 +3751,8 @@
                     "value": 0
                   },
                   {
-                    "id": "displayName"
+                    "id": "displayName",
+                    "value": null
                   },
                   {
                     "id": "color",
@@ -3820,7 +3792,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 3811
+            "y": 56
           },
           "id": 52,
           "interval": "$interval",
@@ -3859,7 +3831,6 @@
               },
               "editorMode": "code",
               "expr": "quantile(0.5, (rocm_utilization_percentage * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) ",
-              "hide": false,
               "instant": false,
               "legendFormat": "Median",
               "range": true,
@@ -3872,7 +3843,6 @@
               },
               "editorMode": "code",
               "expr": "quantile(0.8, (rocm_utilization_percentage * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) ",
-              "hide": false,
               "instant": false,
               "legendFormat": "Quantile 0.8",
               "range": true,
@@ -3885,7 +3855,6 @@
               },
               "editorMode": "code",
               "expr": "avg(rocm_utilization_percentage * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "instant": false,
               "legendFormat": "Average",
               "range": true,
@@ -3907,7 +3876,7 @@
         "x": 0,
         "y": 28
       },
-      "id": 126,
+      "id": 193,
       "panels": [
         {
           "datasource": {
@@ -3952,12 +3921,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3966,14 +3935,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2677
+            "y": 29
           },
           "id": 142,
           "interval": "$interval",
@@ -4061,12 +4029,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4075,14 +4043,13 @@
                 ]
               },
               "unit": "celsius"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3317
+            "y": 669
           },
           "id": 33,
           "interval": "$interval",
@@ -4170,12 +4137,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4184,14 +4151,13 @@
                 ]
               },
               "unit": "celsius"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3325
+            "y": 677
           },
           "id": 128,
           "interval": "$interval",
@@ -4279,12 +4245,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4293,14 +4259,13 @@
                 ]
               },
               "unit": "watt"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3333
+            "y": 685
           },
           "id": 129,
           "interval": "$interval",
@@ -4388,12 +4353,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4402,14 +4367,13 @@
                 ]
               },
               "unit": "rotmhz"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3341
+            "y": 693
           },
           "id": 130,
           "interval": "$interval",
@@ -4497,12 +4461,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4511,14 +4475,13 @@
                 ]
               },
               "unit": "rotmhz"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3341
+            "y": 693
           },
           "id": 131,
           "interval": "$interval",
@@ -4575,7 +4538,7 @@
         "x": 0,
         "y": 29
       },
-      "id": 21,
+      "id": 194,
       "panels": [
         {
           "datasource": {
@@ -4620,12 +4583,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4634,14 +4597,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 4187
+            "y": 30
           },
           "id": 143,
           "interval": "$interval",
@@ -4720,12 +4682,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4734,14 +4696,13 @@
                 ]
               },
               "unit": "celsius"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 4195
+            "y": 38
           },
           "id": 127,
           "interval": "$interval",
@@ -4820,12 +4781,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4834,14 +4795,13 @@
                 ]
               },
               "unit": "celsius"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 4203
+            "y": 46
           },
           "id": 104,
           "interval": "$interval",
@@ -4920,12 +4880,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4934,14 +4894,13 @@
                 ]
               },
               "unit": "watt"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 4211
+            "y": 54
           },
           "id": 22,
           "interval": "$interval",
@@ -5020,12 +4979,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5034,14 +4993,13 @@
                 ]
               },
               "unit": "rotmhz"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4219
+            "y": 62
           },
           "id": 25,
           "interval": "$interval",
@@ -5120,12 +5078,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5134,14 +5092,13 @@
                 ]
               },
               "unit": "rotmhz"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4219
+            "y": 62
           },
           "id": 23,
           "interval": "$interval",
@@ -5189,7 +5146,7 @@
         "x": 0,
         "y": 30
       },
-      "id": 136,
+      "id": 195,
       "panels": [
         {
           "datasource": {
@@ -5234,12 +5191,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5248,14 +5205,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3607
+            "y": 31
           },
           "id": 144,
           "interval": "$interval",
@@ -5343,12 +5299,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5357,14 +5313,13 @@
                 ]
               },
               "unit": "celsius"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3687
+            "y": 111
           },
           "id": 137,
           "interval": "$interval",
@@ -5452,12 +5407,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5466,14 +5421,13 @@
                 ]
               },
               "unit": "celsius"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3695
+            "y": 119
           },
           "id": 138,
           "interval": "$interval",
@@ -5561,12 +5515,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5575,14 +5529,13 @@
                 ]
               },
               "unit": "watt"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3703
+            "y": 127
           },
           "id": 139,
           "interval": "$interval",
@@ -5670,12 +5623,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5684,14 +5637,13 @@
                 ]
               },
               "unit": "rotmhz"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3711
+            "y": 135
           },
           "id": 140,
           "interval": "$interval",
@@ -5779,12 +5731,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5793,14 +5745,13 @@
                 ]
               },
               "unit": "rotmhz"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3711
+            "y": 135
           },
           "id": 141,
           "interval": "$interval",
@@ -5857,7 +5808,7 @@
         "x": 0,
         "y": 31
       },
-      "id": 123,
+      "id": 196,
       "panels": [
         {
           "datasource": {
@@ -5903,7 +5854,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -5918,14 +5868,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2186
+            "y": 32
           },
           "id": 134,
           "interval": "$interval",
@@ -5982,14 +5931,13 @@
         "x": 0,
         "y": 32
       },
-      "id": 157,
+      "id": 197,
       "panels": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${source}"
           },
-          "description": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -6028,7 +5976,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6043,14 +5990,13 @@
                 ]
               },
               "unit": "KBs"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2366
+            "y": 33
           },
           "id": 156,
           "interval": "$interval",
@@ -6101,7 +6047,6 @@
             "type": "prometheus",
             "uid": "${source}"
           },
-          "description": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -6140,7 +6085,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6155,14 +6099,13 @@
                 ]
               },
               "unit": "KBs"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2366
+            "y": 33
           },
           "id": 158,
           "interval": "$interval",
@@ -6220,7 +6163,7 @@
         "x": 0,
         "y": 33
       },
-      "id": 150,
+      "id": 198,
       "panels": [
         {
           "datasource": {
@@ -6266,12 +6209,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6280,14 +6223,13 @@
                 ]
               },
               "unit": "sci"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2713
+            "y": 34
           },
           "id": 151,
           "interval": "$interval",
@@ -6348,7 +6290,7 @@
         "x": 0,
         "y": 34
       },
-      "id": 133,
+      "id": 199,
       "panels": [
         {
           "datasource": {
@@ -6395,7 +6337,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6410,14 +6351,13 @@
                 ]
               },
               "unit": "cps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1453
+            "y": 35
           },
           "id": 125,
           "interval": "$interval",
@@ -6478,7 +6418,7 @@
         "x": 0,
         "y": 35
       },
-      "id": 152,
+      "id": 200,
       "panels": [
         {
           "datasource": {
@@ -6525,7 +6465,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6540,18 +6479,16 @@
                 ]
               },
               "unit": "KBs"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1454
+            "y": 36
           },
           "id": 153,
           "interval": "$interval",
-          "maxPerRow": 2,
           "options": {
             "legend": {
               "calcs": [],
@@ -6639,7 +6576,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6654,18 +6590,16 @@
                 ]
               },
               "unit": "KBs"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1454
+            "y": 36
           },
           "id": 154,
           "interval": "$interval",
-          "maxPerRow": 2,
           "options": {
             "legend": {
               "calcs": [],
@@ -6753,7 +6687,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6768,18 +6701,16 @@
                 ]
               },
               "unit": "flops"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1742
+            "y": 324
           },
           "id": 155,
           "interval": "$interval",
-          "maxPerRow": 2,
           "options": {
             "legend": {
               "calcs": [],
@@ -6867,7 +6798,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6882,14 +6812,13 @@
                 ]
               },
               "unit": "flops"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1750
+            "y": 332
           },
           "id": 165,
           "interval": "$interval",
@@ -6973,7 +6902,6 @@
               },
               "max": 100,
               "min": 0,
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6988,18 +6916,16 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1842
+            "y": 424
           },
           "id": 186,
           "interval": "$interval",
-          "maxPerRow": 2,
           "options": {
             "legend": {
               "calcs": [],
@@ -7089,7 +7015,6 @@
               },
               "max": 100,
               "min": 0,
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7104,18 +7029,16 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1842
+            "y": 424
           },
           "id": 187,
           "interval": "$interval",
-          "maxPerRow": 2,
           "options": {
             "legend": {
               "calcs": [],
@@ -7170,7 +7093,7 @@
         "x": 0,
         "y": 38
       },
-      "id": 44,
+      "id": 203,
       "panels": [
         {
           "datasource": {
@@ -7215,7 +7138,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7230,14 +7152,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2188
+            "y": 39
           },
           "id": 43,
           "interval": "$interval",
@@ -7325,7 +7246,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7340,14 +7260,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2188
+            "y": 39
           },
           "id": 48,
           "interval": "$interval",
@@ -7404,7 +7323,7 @@
         "x": 0,
         "y": 39
       },
-      "id": 122,
+      "id": 204,
       "panels": [
         {
           "datasource": {
@@ -7452,7 +7371,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7466,14 +7384,13 @@
                   }
                 ]
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1947
+            "y": 40
           },
           "id": 120,
           "options": {
@@ -7515,7 +7432,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_sdma_correctable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "SDMA, {{instance}}, {{card}}",
               "range": true,
@@ -7529,7 +7445,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_gfx_correctable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "GFX, {{instance}}, {{card}}",
               "range": true,
@@ -7543,7 +7458,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_mmhub_correctable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "MMHUB, {{instance}}, {{card}}",
               "range": true,
@@ -7557,7 +7471,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_pcie_bif_correctable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "PCIE BIF, {{instance}}, {{card}}",
               "range": true,
@@ -7571,7 +7484,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_hdp_correctable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "HDP, {{instance}}, {{card}}",
               "range": true,
@@ -7585,7 +7497,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_xgmi_wafl_correctable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "XGMI WAFL, {{instance}}, {{card}}",
               "range": true,
@@ -7650,7 +7561,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7664,14 +7574,13 @@
                   }
                 ]
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1947
+            "y": 40
           },
           "id": 121,
           "options": {
@@ -7713,7 +7622,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_sdma_uncorrectable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "SDMA, {{instance}}, {{card}}",
               "range": true,
@@ -7727,7 +7635,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_gfx_uncorrectable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "GFX, {{instance}}, {{card}}",
               "range": true,
@@ -7741,7 +7648,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_mmhub_uncorrectable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "MMHUB, {{instance}}, {{card}}",
               "range": true,
@@ -7755,7 +7661,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_pcie_bif_uncorrectable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "PCIE BIF, {{instance}}, {{card}}",
               "range": true,
@@ -7769,7 +7674,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_hdp_uncorrectable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "HDP, {{instance}}, {{card}}",
               "range": true,
@@ -7783,7 +7687,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_xgmi_wafl_uncorrectable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "XGMI WAFL, {{instance}}, {{card}}",
               "range": true,
@@ -7814,7 +7717,7 @@
         "x": 0,
         "y": 40
       },
-      "id": 101,
+      "id": 205,
       "panels": [
         {
           "datasource": {
@@ -7859,7 +7762,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7874,14 +7776,13 @@
                 ]
               },
               "unit": "binBps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2260
+            "y": 41
           },
           "id": 105,
           "interval": "$interval",
@@ -7970,7 +7871,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7985,14 +7885,13 @@
                 ]
               },
               "unit": "binBps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2260
+            "y": 41
           },
           "id": 106,
           "interval": "$interval",
@@ -8050,7 +7949,7 @@
         "x": 0,
         "y": 41
       },
-      "id": 41,
+      "id": 206,
       "panels": [
         {
           "datasource": {
@@ -8095,7 +7994,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -8110,14 +8008,13 @@
                 ]
               },
               "unit": "binBps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2261
+            "y": 42
           },
           "id": 116,
           "interval": "$interval",
@@ -8206,7 +8103,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -8221,14 +8117,13 @@
                 ]
               },
               "unit": "binBps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2261
+            "y": 42
           },
           "id": 117,
           "interval": "$interval",
@@ -8286,7 +8181,7 @@
         "x": 0,
         "y": 42
       },
-      "id": 83,
+      "id": 207,
       "panels": [
         {
           "datasource": {
@@ -8332,7 +8227,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -8347,14 +8241,13 @@
                 ]
               },
               "unit": "binBps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2032
+            "y": 43
           },
           "id": 46,
           "interval": "$interval",
@@ -8444,7 +8337,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -8459,14 +8351,13 @@
                 ]
               },
               "unit": "binBps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2032
+            "y": 43
           },
           "id": 45,
           "interval": "$interval",
@@ -8524,7 +8415,7 @@
         "x": 0,
         "y": 44
       },
-      "id": 132,
+      "id": 209,
       "panels": [
         {
           "datasource": {
@@ -8570,12 +8461,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -8584,14 +8475,13 @@
                 ]
               },
               "unit": "none"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 6424
+            "y": 45
           },
           "id": 135,
           "interval": "$interval",
@@ -8650,7 +8540,7 @@
         "x": 0,
         "y": 45
       },
-      "id": 57,
+      "id": 210,
       "panels": [
         {
           "datasource": {
@@ -8669,12 +8559,12 @@
                 },
                 "inspect": false
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -8755,7 +8645,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 6473
+            "y": 46
           },
           "id": 56,
           "interval": "$interval",
@@ -8793,7 +8683,6 @@
               },
               "editorMode": "code",
               "expr": "avg by (marker) (avg by (instance) (rocm_utilization_percentage) * on (instance) group_left(jobid,marker) rmsjob_info{jobid=\"$jobid\"} * on (jobid) group_left(marker) count by (jobid,marker) (rmsjob_annotations{jobid=\"$jobid\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -8816,8 +8705,7 @@
                   "last",
                   "range"
                 ]
-              },
-              "topic": "series"
+              }
             },
             {
               "filter": {
@@ -8850,7 +8738,7 @@
         "x": 0,
         "y": 46
       },
-      "id": 111,
+      "id": 211,
       "panels": [
         {
           "datasource": {
@@ -8872,7 +8760,6 @@
                 },
                 "inspect": false
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -9001,7 +8888,6 @@
               },
               "editorMode": "code",
               "expr": "timestamp(count by (jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))*1000",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -9014,7 +8900,6 @@
               },
               "editorMode": "code",
               "expr": "count by (jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0)",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -9038,8 +8923,7 @@
                   "last",
                   "range"
                 ]
-              },
-              "topic": "series"
+              }
             },
             {
               "filter": {
@@ -9116,7 +9000,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -9251,7 +9134,6 @@
                 },
                 "inspect": false
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -9352,7 +9234,6 @@
               },
               "editorMode": "code",
               "expr": "avg by (jobstep) ((rocm_utilization_percentage) * on (instance) group_left(jobid,jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -9365,7 +9246,6 @@
               },
               "editorMode": "code",
               "expr": "max by (jobstep) ((rocm_utilization_percentage) * on (instance) group_left(jobid,jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -9378,7 +9258,6 @@
               },
               "editorMode": "code",
               "expr": "timestamp(count by (jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -9398,8 +9277,7 @@
                 "reducers": [
                   "mean"
                 ]
-              },
-              "topic": "series"
+              }
             },
             {
               "filter": {
@@ -9484,7 +9362,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -9631,7 +9508,6 @@
                 },
                 "inspect": false
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -9732,7 +9608,6 @@
               },
               "editorMode": "code",
               "expr": "avg by (jobstep) ((rocm_vram_used_percentage) * on (instance) group_left(jobid,jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -9745,7 +9620,6 @@
               },
               "editorMode": "code",
               "expr": "max by (jobstep) ((rocm_vram_used_percentage) * on (instance) group_left(jobid,jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -9758,7 +9632,6 @@
               },
               "editorMode": "code",
               "expr": "timestamp(count by (jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -9778,8 +9651,7 @@
                 "reducers": [
                   "mean"
                 ]
-              },
-              "topic": "series"
+              }
             },
             {
               "filter": {
@@ -9864,7 +9736,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -9996,7 +9867,6 @@
             "type": "prometheus",
             "uid": "$source"
           },
-          "description": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -10009,12 +9879,12 @@
                 },
                 "inspect": false
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -10117,7 +9987,6 @@
               },
               "editorMode": "code",
               "expr": "avg by (jobstep) ((rocm_average_socket_power_watts) * on (instance) group_left(jobid,jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -10130,7 +9999,6 @@
               },
               "editorMode": "code",
               "expr": "max by (jobstep) ((rocm_average_socket_power_watts) * on (instance) group_left(jobid,jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -10143,7 +10011,6 @@
               },
               "editorMode": "code",
               "expr": "timestamp(count by (jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -10163,8 +10030,7 @@
                 "reducers": [
                   "mean"
                 ]
-              },
-              "topic": "series"
+              }
             },
             {
               "filter": {
@@ -10249,12 +10115,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -10383,7 +10249,7 @@
         "x": 0,
         "y": 47
       },
-      "id": 177,
+      "id": 212,
       "panels": [
         {
           "datasource": {
@@ -10395,7 +10261,6 @@
               "color": {
                 "mode": "fixed"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -10405,8 +10270,7 @@
                   }
                 ]
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 2,
@@ -10463,7 +10327,6 @@
               "color": {
                 "mode": "fixed"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -10473,8 +10336,7 @@
                   }
                 ]
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 2,
@@ -10531,7 +10393,6 @@
               "color": {
                 "mode": "fixed"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -10541,8 +10402,7 @@
                   }
                 ]
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 2,
@@ -10599,7 +10459,6 @@
               "color": {
                 "mode": "fixed"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -10610,8 +10469,7 @@
                 ]
               },
               "unit": "s"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 2,
@@ -10668,7 +10526,6 @@
               "color": {
                 "mode": "fixed"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -10679,8 +10536,7 @@
                 ]
               },
               "unit": "s"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 2,
@@ -10771,7 +10627,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -10786,8 +10641,7 @@
                 ]
               },
               "unit": "s"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
@@ -10819,7 +10673,6 @@
               },
               "editorMode": "code",
               "expr": "avg by (collector) (omnistat_perf_runtime_seconds{collector=\"total\"} * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "instant": false,
               "legendFormat": "Total [average]",
               "range": true,
@@ -10832,7 +10685,6 @@
               },
               "editorMode": "code",
               "expr": "max by (collector) (omnistat_perf_runtime_seconds{collector=\"total\"} * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "instant": false,
               "legendFormat": "Total [max]",
               "range": true,
@@ -10845,7 +10697,6 @@
               },
               "editorMode": "code",
               "expr": "avg by (collector) (omnistat_perf_runtime_seconds{collector!=\"total\"} * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "instant": false,
               "legendFormat": "Collector: {{collector}} [average]",
               "range": true,
@@ -10858,7 +10709,6 @@
               },
               "editorMode": "code",
               "expr": "max by (collector) (omnistat_perf_runtime_seconds{collector!=\"total\"} * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "instant": false,
               "legendFormat": "Collector: {{collector}} [max]",
               "range": true,
@@ -10912,7 +10762,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -10927,8 +10776,7 @@
                 ]
               },
               "unit": "s"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
@@ -10960,7 +10808,6 @@
               },
               "editorMode": "code",
               "expr": "avg(omnistat_perf_push_seconds * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "instant": false,
               "legendFormat": "Push [average]",
               "range": true,
@@ -10973,7 +10820,6 @@
               },
               "editorMode": "code",
               "expr": "avg(omnistat_perf_push_seconds * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "instant": false,
               "interval": "",
               "legendFormat": "Push [max]",
@@ -10998,7 +10844,6 @@
               },
               "editorMode": "code",
               "expr": "max(omnistat_perf_push_background_seconds * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "legendFormat": "Background Push [max]",
               "range": true,
               "refId": "Background Max"
@@ -11015,28 +10860,32 @@
   "preload": false,
   "refresh": "",
   "schemaVersion": 42,
-  "tags": [],
   "templating": {
     "list": [
       {
         "allowCustomValue": false,
         "hide": 2,
         "includeAll": false,
+        "multi": false,
         "name": "source",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "type": "datasource"
       },
       {
+        "allowCustomValue": true,
         "datasource": {
           "type": "prometheus",
           "uid": "${source}"
         },
         "definition": "label_values(rmsjob_info,jobid)",
+        "hide": 0,
         "includeAll": false,
         "label": "Job ID",
+        "multi": false,
         "name": "jobid",
         "options": [],
         "query": {
@@ -11046,16 +10895,21 @@
         },
         "refresh": 1,
         "regex": "",
-        "sort": 8,
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": 0,
         "type": "query"
       },
       {
+        "allowCustomValue": true,
         "current": {
           "text": "5s",
           "value": "5s"
         },
+        "hide": 0,
         "includeAll": false,
         "label": "Resolution",
+        "multi": false,
         "name": "interval",
         "options": [
           {
@@ -11095,7 +10949,9 @@
           }
         ],
         "query": "0.1s,0.5s,1s,5s,15s,30s,60s",
-        "type": "custom"
+        "skipUrlSync": false,
+        "type": "custom",
+        "valuesFormat": "csv"
       },
       {
         "allowCustomValue": false,
@@ -11107,6 +10963,7 @@
         "hide": 2,
         "includeAll": false,
         "label": "Sampling interval",
+        "multi": false,
         "name": "sampling_interval",
         "options": [],
         "query": {
@@ -11116,6 +10973,9 @@
         },
         "refresh": 2,
         "regex": "/interval_secs=\"([^\"]*)\"/",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": 0,
         "type": "query"
       },
       {
@@ -11142,6 +11002,8 @@
         },
         "refresh": 2,
         "regex": "/.*name=\"([^\"]*).*/",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
         "sort": 1,
         "type": "query"
       },
@@ -11169,6 +11031,8 @@
         },
         "refresh": 2,
         "regex": "/.*name=\"([^\"]*).*/",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
         "sort": 1,
         "type": "query"
       },
@@ -11196,6 +11060,9 @@
         },
         "refresh": 2,
         "regex": "/.*kernel=\"([^\"]*).*/",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": 0,
         "type": "query"
       }
     ]
@@ -11205,9 +11072,8 @@
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "",
+  "timezone": "browser",
   "title": "Job - RMS",
   "uid": "fdqo0h2s2drswe-rms",
-  "version": 1,
-  "weekStart": ""
+  "version": 1
 }

--- a/grafana/source/job.json
+++ b/grafana/source/job.json
@@ -55,8 +55,7 @@
         "x": 0,
         "y": 0
       },
-      "id": 35,
-      "panels": [],
+      "id": 188,
       "title": "Job Info",
       "type": "row"
     },
@@ -70,7 +69,6 @@
           "color": {
             "mode": "fixed"
           },
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -80,8 +78,7 @@
               }
             ]
           }
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 3,
@@ -110,7 +107,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -140,7 +137,6 @@
           "color": {
             "mode": "fixed"
           },
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -150,8 +146,7 @@
               }
             ]
           }
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 3,
@@ -180,7 +175,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -214,7 +209,6 @@
           "color": {
             "mode": "fixed"
           },
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -224,8 +218,7 @@
               }
             ]
           }
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 3,
@@ -254,7 +247,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -312,8 +305,7 @@
               }
             ]
           }
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 3,
@@ -342,7 +334,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -386,7 +378,6 @@
           "color": {
             "mode": "fixed"
           },
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -396,8 +387,7 @@
               }
             ]
           }
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 3,
@@ -426,7 +416,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -455,7 +445,6 @@
           "color": {
             "mode": "fixed"
           },
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -465,8 +454,7 @@
               }
             ]
           }
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 3,
@@ -495,7 +483,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -523,7 +511,6 @@
           "color": {
             "mode": "fixed"
           },
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -534,8 +521,7 @@
             ]
           },
           "unit": "dthms"
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 3,
@@ -564,7 +550,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -573,7 +559,6 @@
           },
           "editorMode": "code",
           "expr": "max(timestamp(rmsjob_info{jobid=\"$jobid\"}))",
-          "hide": false,
           "instant": false,
           "interval": "",
           "legendFormat": "__auto",
@@ -592,8 +577,7 @@
         "x": 0,
         "y": 4
       },
-      "id": 66,
-      "panels": [],
+      "id": 189,
       "title": "Performance Overview",
       "type": "row"
     },
@@ -609,7 +593,6 @@
             "mode": "thresholds"
           },
           "decimals": 0,
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -628,8 +611,7 @@
             ]
           },
           "unit": "percent"
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 4,
@@ -655,7 +637,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -721,7 +703,6 @@
               "mode": "off"
             }
           },
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -788,6 +769,10 @@
       "id": 58,
       "interval": "$interval",
       "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
         "legend": {
           "calcs": [],
           "displayMode": "list",
@@ -801,7 +786,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -822,13 +807,13 @@
           },
           "editorMode": "code",
           "expr": "max(rocm_utilization_percentage * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-          "hide": false,
           "instant": false,
           "legendFormat": "Max",
           "range": true,
           "refId": "B"
         }
       ],
+      "title": "",
       "type": "timeseries"
     },
     {
@@ -843,7 +828,6 @@
             "mode": "thresholds"
           },
           "decimals": 0,
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -862,8 +846,7 @@
             ]
           },
           "unit": "percent"
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 4,
@@ -889,7 +872,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -955,7 +938,6 @@
               "mode": "off"
             }
           },
-          "mappings": [],
           "max": 100,
           "min": 0,
           "thresholds": {
@@ -1024,6 +1006,10 @@
       "id": 61,
       "interval": "$interval",
       "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
         "legend": {
           "calcs": [],
           "displayMode": "list",
@@ -1037,7 +1023,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -1058,13 +1044,13 @@
           },
           "editorMode": "code",
           "expr": "max(rocm_vram_used_percentage * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-          "hide": false,
           "instant": false,
           "legendFormat": "Max",
           "range": true,
           "refId": "B"
         }
       ],
+      "title": "",
       "type": "timeseries"
     },
     {
@@ -1079,7 +1065,6 @@
             "mode": "fixed"
           },
           "decimals": 0,
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1098,8 +1083,7 @@
             ]
           },
           "unit": "percent"
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 4,
@@ -1125,7 +1109,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -1189,7 +1173,6 @@
               "mode": "off"
             }
           },
-          "mappings": [],
           "min": 0,
           "thresholds": {
             "mode": "absolute",
@@ -1233,6 +1216,10 @@
       "id": 63,
       "interval": "$interval",
       "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
         "legend": {
           "calcs": [],
           "displayMode": "list",
@@ -1246,7 +1233,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -1261,6 +1248,7 @@
           "refId": "A"
         }
       ],
+      "title": "",
       "type": "timeseries"
     },
     {
@@ -1275,7 +1263,6 @@
             "mode": "thresholds"
           },
           "decimals": 0,
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1294,8 +1281,7 @@
             ]
           },
           "unit": "percent"
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 4,
@@ -1321,7 +1307,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -1387,7 +1373,6 @@
               "mode": "off"
             }
           },
-          "mappings": [],
           "max": 100,
           "min": 0,
           "thresholds": {
@@ -1432,6 +1417,10 @@
       "id": 65,
       "interval": "$interval",
       "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
         "legend": {
           "calcs": [],
           "displayMode": "list",
@@ -1445,7 +1434,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -1460,6 +1449,7 @@
           "refId": "A"
         }
       ],
+      "title": "",
       "type": "timeseries"
     },
     {
@@ -1474,7 +1464,6 @@
             "mode": "fixed"
           },
           "decimals": 0,
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1493,8 +1482,7 @@
             ]
           },
           "unit": "binBps"
-        },
-        "overrides": []
+        }
       },
       "gridPos": {
         "h": 4,
@@ -1521,7 +1509,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -1543,7 +1531,6 @@
           },
           "editorMode": "code",
           "expr": "sum(rate(omnistat_network_rx_bytes{device_class!=\"net\"}[$__rate_interval]) * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"}) + sum(rate(omnistat_network_tx_bytes{device_class!=\"net\"}[$__rate_interval]) * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-          "hide": false,
           "instant": false,
           "interval": "$interval",
           "legendFormat": "High Performance Interconnect",
@@ -1600,7 +1587,6 @@
               "mode": "off"
             }
           },
-          "mappings": [],
           "min": 0,
           "thresholds": {
             "mode": "absolute",
@@ -1659,6 +1645,10 @@
       "id": 119,
       "interval": "$interval",
       "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
         "legend": {
           "calcs": [],
           "displayMode": "list",
@@ -1672,7 +1662,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.3.1",
+      "pluginVersion": "13.0.1",
       "targets": [
         {
           "datasource": {
@@ -1681,7 +1671,6 @@
           },
           "editorMode": "code",
           "expr": "sum(rate(omnistat_network_rx_bytes{device_class=\"net\"}[$__rate_interval]) * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-          "hide": false,
           "instant": false,
           "interval": "$interval",
           "legendFormat": "Eth Rx",
@@ -1695,7 +1684,6 @@
           },
           "editorMode": "code",
           "expr": "sum(rate(omnistat_network_tx_bytes{device_class=\"net\"}[$__rate_interval]) * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-          "hide": false,
           "instant": false,
           "interval": "$interval",
           "legendFormat": "Eth Tx",
@@ -1722,7 +1710,6 @@
           },
           "editorMode": "code",
           "expr": "sum(rate(omnistat_network_tx_bytes{device_class!=\"net\"}[$__rate_interval]) * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-          "hide": false,
           "instant": false,
           "interval": "$interval",
           "legendFormat": "Other Tx",
@@ -1730,6 +1717,7 @@
           "refId": "B"
         }
       ],
+      "title": "",
       "type": "timeseries"
     },
     {
@@ -1740,7 +1728,7 @@
         "x": 0,
         "y": 25
       },
-      "id": 82,
+      "id": 190,
       "panels": [
         {
           "datasource": {
@@ -1759,14 +1747,13 @@
                   "type": "linear"
                 }
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 836
+            "y": 26
           },
           "id": 88,
           "interval": "$interval",
@@ -1869,14 +1856,13 @@
                   "type": "linear"
                 }
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 836
+            "y": 26
           },
           "id": 89,
           "interval": "$interval",
@@ -2005,12 +1991,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2019,14 +2005,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 883
+            "y": 73
           },
           "id": 91,
           "interval": "$interval",
@@ -2102,15 +2087,14 @@
                   "mode": "off"
                 }
               },
-              "fieldMinMax": true,
-              "mappings": [],
               "max": 100,
               "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2177,7 +2161,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 891
+            "y": 81
           },
           "id": 99,
           "interval": "$interval",
@@ -2283,13 +2267,12 @@
                 },
                 "inspect": false
               },
-              "fieldMinMax": false,
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2341,7 +2324,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 891
+            "y": 81
           },
           "id": 100,
           "interval": "$interval",
@@ -2388,8 +2371,7 @@
                 "reducers": [
                   "mean"
                 ]
-              },
-              "topic": "series"
+              }
             },
             {
               "disabled": true,
@@ -2452,7 +2434,7 @@
         "x": 0,
         "y": 26
       },
-      "id": 15,
+      "id": 191,
       "panels": [
         {
           "datasource": {
@@ -2465,12 +2447,12 @@
                 "mode": "thresholds"
               },
               "decimals": 2,
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "#EAB839",
@@ -2483,14 +2465,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 3782
+            "y": 27
           },
           "id": 28,
           "interval": "$interval",
@@ -2545,14 +2526,13 @@
                   "type": "linear"
                 }
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 3782
+            "y": 27
           },
           "id": 86,
           "interval": "$interval",
@@ -2640,12 +2620,12 @@
                 "mode": "thresholds"
               },
               "decimals": 2,
-              "mappings": [],
               "thresholds": {
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "#EAB839",
@@ -2658,14 +2638,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 4168
+            "y": 413
           },
           "id": 29,
           "interval": "$interval",
@@ -2720,14 +2699,13 @@
                   "type": "linear"
                 }
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 15,
             "x": 9,
-            "y": 4168
+            "y": 413
           },
           "id": 31,
           "interval": "$interval",
@@ -2847,12 +2825,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2861,14 +2839,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 4176
+            "y": 421
           },
           "id": 24,
           "interval": "$interval",
@@ -2916,7 +2893,7 @@
         "x": 0,
         "y": 27
       },
-      "id": 81,
+      "id": 192,
       "panels": [
         {
           "datasource": {
@@ -2935,14 +2912,13 @@
                   "type": "linear"
                 }
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 3783
+            "y": 28
           },
           "id": 27,
           "interval": "$interval",
@@ -3045,14 +3021,13 @@
                   "type": "linear"
                 }
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 3783
+            "y": 28
           },
           "id": 87,
           "interval": "$interval",
@@ -3181,12 +3156,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3195,14 +3170,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3794
+            "y": 39
           },
           "id": 90,
           "interval": "$interval",
@@ -3278,15 +3252,14 @@
                   "mode": "off"
                 }
               },
-              "fieldMinMax": true,
-              "mappings": [],
               "max": 100,
               "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3369,7 +3342,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 3802
+            "y": 47
           },
           "id": 98,
           "interval": "$interval",
@@ -3491,13 +3464,12 @@
                 },
                 "inspect": false
               },
-              "fieldMinMax": false,
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3549,7 +3521,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 3802
+            "y": 47
           },
           "id": 95,
           "interval": "$interval",
@@ -3596,8 +3568,7 @@
                 "reducers": [
                   "mean"
                 ]
-              },
-              "topic": "series"
+              }
             },
             {
               "id": "extractFields",
@@ -3691,12 +3662,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -3780,7 +3751,8 @@
                     "value": 0
                   },
                   {
-                    "id": "displayName"
+                    "id": "displayName",
+                    "value": null
                   },
                   {
                     "id": "color",
@@ -3820,7 +3792,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 3811
+            "y": 56
           },
           "id": 52,
           "interval": "$interval",
@@ -3859,7 +3831,6 @@
               },
               "editorMode": "code",
               "expr": "quantile(0.5, (rocm_utilization_percentage * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) ",
-              "hide": false,
               "instant": false,
               "legendFormat": "Median",
               "range": true,
@@ -3872,7 +3843,6 @@
               },
               "editorMode": "code",
               "expr": "quantile(0.8, (rocm_utilization_percentage * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) ",
-              "hide": false,
               "instant": false,
               "legendFormat": "Quantile 0.8",
               "range": true,
@@ -3885,7 +3855,6 @@
               },
               "editorMode": "code",
               "expr": "avg(rocm_utilization_percentage * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "instant": false,
               "legendFormat": "Average",
               "range": true,
@@ -3907,7 +3876,7 @@
         "x": 0,
         "y": 28
       },
-      "id": 126,
+      "id": 193,
       "panels": [
         {
           "datasource": {
@@ -3952,12 +3921,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3966,14 +3935,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2677
+            "y": 29
           },
           "id": 142,
           "interval": "$interval",
@@ -4061,12 +4029,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4075,14 +4043,13 @@
                 ]
               },
               "unit": "celsius"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3317
+            "y": 669
           },
           "id": 33,
           "interval": "$interval",
@@ -4170,12 +4137,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4184,14 +4151,13 @@
                 ]
               },
               "unit": "celsius"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3325
+            "y": 677
           },
           "id": 128,
           "interval": "$interval",
@@ -4279,12 +4245,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4293,14 +4259,13 @@
                 ]
               },
               "unit": "watt"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3333
+            "y": 685
           },
           "id": 129,
           "interval": "$interval",
@@ -4388,12 +4353,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4402,14 +4367,13 @@
                 ]
               },
               "unit": "rotmhz"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3341
+            "y": 693
           },
           "id": 130,
           "interval": "$interval",
@@ -4497,12 +4461,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4511,14 +4475,13 @@
                 ]
               },
               "unit": "rotmhz"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3341
+            "y": 693
           },
           "id": 131,
           "interval": "$interval",
@@ -4575,7 +4538,7 @@
         "x": 0,
         "y": 29
       },
-      "id": 21,
+      "id": 194,
       "panels": [
         {
           "datasource": {
@@ -4620,12 +4583,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4634,14 +4597,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 4187
+            "y": 30
           },
           "id": 143,
           "interval": "$interval",
@@ -4720,12 +4682,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4734,14 +4696,13 @@
                 ]
               },
               "unit": "celsius"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 4195
+            "y": 38
           },
           "id": 127,
           "interval": "$interval",
@@ -4820,12 +4781,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4834,14 +4795,13 @@
                 ]
               },
               "unit": "celsius"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 4203
+            "y": 46
           },
           "id": 104,
           "interval": "$interval",
@@ -4920,12 +4880,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4934,14 +4894,13 @@
                 ]
               },
               "unit": "watt"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 4211
+            "y": 54
           },
           "id": 22,
           "interval": "$interval",
@@ -5020,12 +4979,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5034,14 +4993,13 @@
                 ]
               },
               "unit": "rotmhz"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4219
+            "y": 62
           },
           "id": 25,
           "interval": "$interval",
@@ -5120,12 +5078,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5134,14 +5092,13 @@
                 ]
               },
               "unit": "rotmhz"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4219
+            "y": 62
           },
           "id": 23,
           "interval": "$interval",
@@ -5189,7 +5146,7 @@
         "x": 0,
         "y": 30
       },
-      "id": 136,
+      "id": 195,
       "panels": [
         {
           "datasource": {
@@ -5234,12 +5191,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5248,14 +5205,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3607
+            "y": 31
           },
           "id": 144,
           "interval": "$interval",
@@ -5343,12 +5299,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5357,14 +5313,13 @@
                 ]
               },
               "unit": "celsius"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3687
+            "y": 111
           },
           "id": 137,
           "interval": "$interval",
@@ -5452,12 +5407,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5466,14 +5421,13 @@
                 ]
               },
               "unit": "celsius"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3695
+            "y": 119
           },
           "id": 138,
           "interval": "$interval",
@@ -5561,12 +5515,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5575,14 +5529,13 @@
                 ]
               },
               "unit": "watt"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3703
+            "y": 127
           },
           "id": 139,
           "interval": "$interval",
@@ -5670,12 +5623,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5684,14 +5637,13 @@
                 ]
               },
               "unit": "rotmhz"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3711
+            "y": 135
           },
           "id": 140,
           "interval": "$interval",
@@ -5779,12 +5731,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5793,14 +5745,13 @@
                 ]
               },
               "unit": "rotmhz"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3711
+            "y": 135
           },
           "id": 141,
           "interval": "$interval",
@@ -5857,7 +5808,7 @@
         "x": 0,
         "y": 31
       },
-      "id": 123,
+      "id": 196,
       "panels": [
         {
           "datasource": {
@@ -5903,7 +5854,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -5918,14 +5868,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2186
+            "y": 32
           },
           "id": 134,
           "interval": "$interval",
@@ -5982,14 +5931,13 @@
         "x": 0,
         "y": 32
       },
-      "id": 157,
+      "id": 197,
       "panels": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${source}"
           },
-          "description": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -6028,7 +5976,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6043,14 +5990,13 @@
                 ]
               },
               "unit": "KBs"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2366
+            "y": 33
           },
           "id": 156,
           "interval": "$interval",
@@ -6101,7 +6047,6 @@
             "type": "prometheus",
             "uid": "${source}"
           },
-          "description": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -6140,7 +6085,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6155,14 +6099,13 @@
                 ]
               },
               "unit": "KBs"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2366
+            "y": 33
           },
           "id": 158,
           "interval": "$interval",
@@ -6220,7 +6163,7 @@
         "x": 0,
         "y": 33
       },
-      "id": 150,
+      "id": 198,
       "panels": [
         {
           "datasource": {
@@ -6266,12 +6209,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6280,14 +6223,13 @@
                 ]
               },
               "unit": "sci"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2713
+            "y": 34
           },
           "id": 151,
           "interval": "$interval",
@@ -6348,7 +6290,7 @@
         "x": 0,
         "y": 34
       },
-      "id": 133,
+      "id": 199,
       "panels": [
         {
           "datasource": {
@@ -6395,7 +6337,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6410,14 +6351,13 @@
                 ]
               },
               "unit": "cps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1453
+            "y": 35
           },
           "id": 125,
           "interval": "$interval",
@@ -6478,7 +6418,7 @@
         "x": 0,
         "y": 35
       },
-      "id": 152,
+      "id": 200,
       "panels": [
         {
           "datasource": {
@@ -6525,7 +6465,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6540,18 +6479,16 @@
                 ]
               },
               "unit": "KBs"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1454
+            "y": 36
           },
           "id": 153,
           "interval": "$interval",
-          "maxPerRow": 2,
           "options": {
             "legend": {
               "calcs": [],
@@ -6639,7 +6576,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6654,18 +6590,16 @@
                 ]
               },
               "unit": "KBs"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1454
+            "y": 36
           },
           "id": 154,
           "interval": "$interval",
-          "maxPerRow": 2,
           "options": {
             "legend": {
               "calcs": [],
@@ -6753,7 +6687,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6768,18 +6701,16 @@
                 ]
               },
               "unit": "flops"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1742
+            "y": 324
           },
           "id": 155,
           "interval": "$interval",
-          "maxPerRow": 2,
           "options": {
             "legend": {
               "calcs": [],
@@ -6867,7 +6798,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6882,14 +6812,13 @@
                 ]
               },
               "unit": "flops"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1750
+            "y": 332
           },
           "id": 165,
           "interval": "$interval",
@@ -6973,7 +6902,6 @@
               },
               "max": 100,
               "min": 0,
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6988,18 +6916,16 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1842
+            "y": 424
           },
           "id": 186,
           "interval": "$interval",
-          "maxPerRow": 2,
           "options": {
             "legend": {
               "calcs": [],
@@ -7089,7 +7015,6 @@
               },
               "max": 100,
               "min": 0,
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7104,18 +7029,16 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1842
+            "y": 424
           },
           "id": 187,
           "interval": "$interval",
-          "maxPerRow": 2,
           "options": {
             "legend": {
               "calcs": [],
@@ -7170,7 +7093,7 @@
         "x": 0,
         "y": 36
       },
-      "id": 168,
+      "id": 201,
       "panels": [
         {
           "datasource": {
@@ -7183,7 +7106,6 @@
               "color": {
                 "mode": "thresholds"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7198,14 +7120,13 @@
                 ]
               },
               "unit": "none"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
-            "h": 2,
+            "h": 3,
             "w": 8,
             "x": 0,
-            "y": 847
+            "y": 37
           },
           "id": 174,
           "interval": "$interval",
@@ -7226,7 +7147,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "12.3.1",
+          "pluginVersion": "13.0.1",
           "targets": [
             {
               "datasource": {
@@ -7256,7 +7177,6 @@
               "color": {
                 "mode": "thresholds"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7271,14 +7191,13 @@
                 ]
               },
               "unit": "none"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
-            "h": 2,
+            "h": 3,
             "w": 8,
             "x": 8,
-            "y": 847
+            "y": 37
           },
           "id": 175,
           "interval": "$interval",
@@ -7299,7 +7218,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "12.3.1",
+          "pluginVersion": "13.0.1",
           "targets": [
             {
               "datasource": {
@@ -7329,7 +7248,6 @@
               "color": {
                 "mode": "thresholds"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7344,14 +7262,13 @@
                 ]
               },
               "unit": "none"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
-            "h": 2,
+            "h": 3,
             "w": 8,
             "x": 16,
-            "y": 847
+            "y": 37
           },
           "id": 176,
           "interval": "$interval",
@@ -7372,7 +7289,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "12.3.1",
+          "pluginVersion": "13.0.1",
           "targets": [
             {
               "datasource": {
@@ -7412,7 +7329,6 @@
                 },
                 "inspect": false
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7440,6 +7356,52 @@
                     "value": "none"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Min"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "from": 1000000000000000,
+                          "result": {
+                            "index": 0,
+                            "text": "-"
+                          }
+                        },
+                        "type": "range"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Max"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "from": 1000000000000000,
+                          "result": {
+                            "index": 0,
+                            "text": "-"
+                          }
+                        },
+                        "type": "range"
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           },
@@ -7447,7 +7409,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 849
+            "y": 40
           },
           "id": 169,
           "interval": "$interval",
@@ -7455,7 +7417,7 @@
             "cellHeight": "sm",
             "showHeader": true
           },
-          "pluginVersion": "12.3.1",
+          "pluginVersion": "13.0.1",
           "targets": [
             {
               "datasource": {
@@ -7480,7 +7442,6 @@
               "exemplar": false,
               "expr": "sum by (kernel) (increase(omnistat_kernel_total_duration_ns[$__range]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"}))",
               "format": "table",
-              "hide": false,
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -7495,7 +7456,6 @@
               "exemplar": false,
               "expr": "sum by (kernel) (increase(omnistat_kernel_dispatch_count[$__range]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"}))",
               "format": "table",
-              "hide": false,
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -7510,7 +7470,6 @@
               "exemplar": false,
               "expr": "sum by (kernel) (increase(omnistat_kernel_total_duration_ns[$__range]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"})) / sum by (kernel) (increase(omnistat_kernel_dispatch_count[$__range]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"}))",
               "format": "table",
-              "hide": false,
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -7571,6 +7530,15 @@
                       }
                     },
                     "fieldName": "Value #B (sum)"
+                  },
+                  {
+                    "config": {
+                      "id": "greater",
+                      "options": {
+                        "value": 0
+                      }
+                    },
+                    "fieldName": "Value #C (sum)"
                   }
                 ],
                 "match": "all",
@@ -7659,7 +7627,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7674,18 +7641,21 @@
                 ]
               },
               "unit": "ns"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 857
+            "y": 48
           },
           "id": 170,
           "interval": "$interval",
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [],
               "displayMode": "list",
@@ -7698,7 +7668,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.3.1",
+          "pluginVersion": "13.0.1",
           "targets": [
             {
               "datasource": {
@@ -7706,7 +7676,7 @@
                 "uid": "${source}"
               },
               "editorMode": "code",
-              "expr": "avg by (kernel) ((increase(omnistat_kernel_total_duration_ns{kernel=~\"$top_kernels\"}[$__rate_interval]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"})) / (increase(omnistat_kernel_dispatch_count{kernel=~\"$top_kernels\"}[$__rate_interval]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"})))",
+              "expr": "(avg by (kernel) ((increase(omnistat_kernel_total_duration_ns{kernel=~\"$top_kernels\"}[$__rate_interval]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"})) / (increase(omnistat_kernel_dispatch_count{kernel=~\"$top_kernels\"}[$__rate_interval]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"})))) > 0",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -7727,7 +7697,7 @@
         "x": 0,
         "y": 37
       },
-      "id": 171,
+      "id": 202,
       "panels": [
         {
           "datasource": {
@@ -7773,7 +7743,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7788,18 +7757,21 @@
                 ]
               },
               "unit": "ns"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1456
+            "y": 38
           },
           "id": 172,
           "interval": "$interval",
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [],
               "displayMode": "list",
@@ -7812,7 +7784,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.3.1",
+          "pluginVersion": "13.0.1",
           "repeat": "top_kernels",
           "repeatDirection": "v",
           "targets": [
@@ -7822,7 +7794,7 @@
                 "uid": "${source}"
               },
               "editorMode": "code",
-              "expr": "avg by (instance,card) ((increase(omnistat_kernel_total_duration_ns{kernel=\"$top_kernels\"}[$__rate_interval]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"})) / (increase(omnistat_kernel_dispatch_count{kernel=\"$top_kernels\"}[$__rate_interval]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"})))",
+              "expr": "(avg by (instance,card) ((increase(omnistat_kernel_total_duration_ns{kernel=\"$top_kernels\"}[$__rate_interval]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"})) / (increase(omnistat_kernel_dispatch_count{kernel=\"$top_kernels\"}[$__rate_interval]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"})))) > 0",
               "legendFormat": "GPU: {{instance}}/{{card}}",
               "range": true,
               "refId": "A"
@@ -7851,7 +7823,6 @@
                 },
                 "inspect": false
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7898,7 +7869,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1456
+            "y": 38
           },
           "id": 173,
           "interval": "$interval",
@@ -7906,7 +7877,7 @@
             "cellHeight": "sm",
             "showHeader": true
           },
-          "pluginVersion": "12.3.1",
+          "pluginVersion": "13.0.1",
           "repeat": "top_kernels",
           "repeatDirection": "v",
           "targets": [
@@ -7933,7 +7904,6 @@
               "exemplar": false,
               "expr": "sum by (instance,card) (increase(omnistat_kernel_total_duration_ns{kernel=\"$top_kernels\"}[$__range]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"}))",
               "format": "table",
-              "hide": false,
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -7948,7 +7918,6 @@
               "exemplar": false,
               "expr": "sum by (instance,card) (increase(omnistat_kernel_dispatch_count{kernel=\"$top_kernels\"}[$__range]) * on (instance) group_left() (rmsjob_info{jobid=\"$jobid\"}))",
               "format": "table",
-              "hide": false,
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -8046,7 +8015,7 @@
         "x": 0,
         "y": 38
       },
-      "id": 44,
+      "id": 203,
       "panels": [
         {
           "datasource": {
@@ -8091,7 +8060,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -8106,14 +8074,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2188
+            "y": 39
           },
           "id": 43,
           "interval": "$interval",
@@ -8201,7 +8168,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -8216,14 +8182,13 @@
                 ]
               },
               "unit": "percent"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2188
+            "y": 39
           },
           "id": 48,
           "interval": "$interval",
@@ -8280,7 +8245,7 @@
         "x": 0,
         "y": 39
       },
-      "id": 122,
+      "id": 204,
       "panels": [
         {
           "datasource": {
@@ -8328,7 +8293,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -8342,14 +8306,13 @@
                   }
                 ]
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1947
+            "y": 40
           },
           "id": 120,
           "options": {
@@ -8391,7 +8354,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_sdma_correctable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "SDMA, {{instance}}, {{card}}",
               "range": true,
@@ -8405,7 +8367,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_gfx_correctable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "GFX, {{instance}}, {{card}}",
               "range": true,
@@ -8419,7 +8380,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_mmhub_correctable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "MMHUB, {{instance}}, {{card}}",
               "range": true,
@@ -8433,7 +8393,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_pcie_bif_correctable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "PCIE BIF, {{instance}}, {{card}}",
               "range": true,
@@ -8447,7 +8406,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_hdp_correctable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "HDP, {{instance}}, {{card}}",
               "range": true,
@@ -8461,7 +8419,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_xgmi_wafl_correctable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "XGMI WAFL, {{instance}}, {{card}}",
               "range": true,
@@ -8526,7 +8483,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -8540,14 +8496,13 @@
                   }
                 ]
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1947
+            "y": 40
           },
           "id": 121,
           "options": {
@@ -8589,7 +8544,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_sdma_uncorrectable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "SDMA, {{instance}}, {{card}}",
               "range": true,
@@ -8603,7 +8557,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_gfx_uncorrectable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "GFX, {{instance}}, {{card}}",
               "range": true,
@@ -8617,7 +8570,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_mmhub_uncorrectable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "MMHUB, {{instance}}, {{card}}",
               "range": true,
@@ -8631,7 +8583,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_pcie_bif_uncorrectable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "PCIE BIF, {{instance}}, {{card}}",
               "range": true,
@@ -8645,7 +8596,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_hdp_uncorrectable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "HDP, {{instance}}, {{card}}",
               "range": true,
@@ -8659,7 +8609,6 @@
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum by (instance,card) (delta(rocm_ras_xgmi_wafl_uncorrectable_count[1m] * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})) > 0",
-              "hide": false,
               "instant": false,
               "legendFormat": "XGMI WAFL, {{instance}}, {{card}}",
               "range": true,
@@ -8690,7 +8639,7 @@
         "x": 0,
         "y": 40
       },
-      "id": 101,
+      "id": 205,
       "panels": [
         {
           "datasource": {
@@ -8735,7 +8684,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -8750,14 +8698,13 @@
                 ]
               },
               "unit": "binBps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2260
+            "y": 41
           },
           "id": 105,
           "interval": "$interval",
@@ -8846,7 +8793,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -8861,14 +8807,13 @@
                 ]
               },
               "unit": "binBps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2260
+            "y": 41
           },
           "id": 106,
           "interval": "$interval",
@@ -8926,7 +8871,7 @@
         "x": 0,
         "y": 41
       },
-      "id": 41,
+      "id": 206,
       "panels": [
         {
           "datasource": {
@@ -8971,7 +8916,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -8986,14 +8930,13 @@
                 ]
               },
               "unit": "binBps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2261
+            "y": 42
           },
           "id": 116,
           "interval": "$interval",
@@ -9082,7 +9025,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -9097,14 +9039,13 @@
                 ]
               },
               "unit": "binBps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2261
+            "y": 42
           },
           "id": 117,
           "interval": "$interval",
@@ -9162,7 +9103,7 @@
         "x": 0,
         "y": 42
       },
-      "id": 83,
+      "id": 207,
       "panels": [
         {
           "datasource": {
@@ -9208,7 +9149,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -9223,14 +9163,13 @@
                 ]
               },
               "unit": "binBps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2032
+            "y": 43
           },
           "id": 46,
           "interval": "$interval",
@@ -9320,7 +9259,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -9335,14 +9273,13 @@
                 ]
               },
               "unit": "binBps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2032
+            "y": 43
           },
           "id": 45,
           "interval": "$interval",
@@ -9433,7 +9370,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -9448,14 +9384,13 @@
                 ]
               },
               "unit": "binBps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2040
+            "y": 51
           },
           "id": 159,
           "interval": "$interval",
@@ -9546,7 +9481,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -9561,14 +9495,13 @@
                 ]
               },
               "unit": "binBps"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2040
+            "y": 51
           },
           "id": 160,
           "interval": "$interval",
@@ -9625,7 +9558,6 @@
               "color": {
                 "mode": "fixed"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -9636,14 +9568,13 @@
                 ]
               },
               "unit": "bytes"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 3,
             "w": 12,
             "x": 0,
-            "y": 2048
+            "y": 59
           },
           "id": 161,
           "interval": "$interval",
@@ -9702,7 +9633,6 @@
               "color": {
                 "mode": "fixed"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -9713,14 +9643,13 @@
                 ]
               },
               "unit": "bytes"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 3,
             "w": 12,
             "x": 12,
-            "y": 2048
+            "y": 59
           },
           "id": 162,
           "interval": "$interval",
@@ -9780,14 +9709,13 @@
         "x": 0,
         "y": 43
       },
-      "id": 145,
+      "id": 208,
       "panels": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${source}"
           },
-          "description": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -9826,7 +9754,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -9841,14 +9768,13 @@
                 ]
               },
               "unit": "watt"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2271
+            "y": 44
           },
           "id": 146,
           "interval": "$interval",
@@ -9898,7 +9824,6 @@
             "type": "prometheus",
             "uid": "${source}"
           },
-          "description": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -9937,7 +9862,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -9952,14 +9876,13 @@
                 ]
               },
               "unit": "watt"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2279
+            "y": 52
           },
           "id": 149,
           "interval": "$interval",
@@ -10047,12 +9970,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -10061,14 +9984,13 @@
                 ]
               },
               "unit": "watt"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2287
+            "y": 60
           },
           "id": 147,
           "interval": "$interval",
@@ -10156,12 +10078,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -10170,14 +10092,13 @@
                 ]
               },
               "unit": "watt"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2295
+            "y": 68
           },
           "id": 148,
           "interval": "$interval",
@@ -10234,7 +10155,7 @@
         "x": 0,
         "y": 44
       },
-      "id": 132,
+      "id": 209,
       "panels": [
         {
           "datasource": {
@@ -10280,12 +10201,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -10294,14 +10215,13 @@
                 ]
               },
               "unit": "none"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 6424
+            "y": 45
           },
           "id": 135,
           "interval": "$interval",
@@ -10360,7 +10280,7 @@
         "x": 0,
         "y": 45
       },
-      "id": 57,
+      "id": 210,
       "panels": [
         {
           "datasource": {
@@ -10379,12 +10299,12 @@
                 },
                 "inspect": false
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -10465,7 +10385,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 6473
+            "y": 46
           },
           "id": 56,
           "interval": "$interval",
@@ -10503,7 +10423,6 @@
               },
               "editorMode": "code",
               "expr": "avg by (marker) (avg by (instance) (rocm_utilization_percentage) * on (instance) group_left(jobid,marker) rmsjob_info{jobid=\"$jobid\"} * on (jobid) group_left(marker) count by (jobid,marker) (rmsjob_annotations{jobid=\"$jobid\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -10526,8 +10445,7 @@
                   "last",
                   "range"
                 ]
-              },
-              "topic": "series"
+              }
             },
             {
               "filter": {
@@ -10560,7 +10478,7 @@
         "x": 0,
         "y": 46
       },
-      "id": 111,
+      "id": 211,
       "panels": [
         {
           "datasource": {
@@ -10582,7 +10500,6 @@
                 },
                 "inspect": false
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -10711,7 +10628,6 @@
               },
               "editorMode": "code",
               "expr": "timestamp(count by (jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))*1000",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -10724,7 +10640,6 @@
               },
               "editorMode": "code",
               "expr": "count by (jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0)",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -10748,8 +10663,7 @@
                   "last",
                   "range"
                 ]
-              },
-              "topic": "series"
+              }
             },
             {
               "filter": {
@@ -10826,7 +10740,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -10961,7 +10874,6 @@
                 },
                 "inspect": false
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -11062,7 +10974,6 @@
               },
               "editorMode": "code",
               "expr": "avg by (jobstep) ((rocm_utilization_percentage) * on (instance) group_left(jobid,jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -11075,7 +10986,6 @@
               },
               "editorMode": "code",
               "expr": "max by (jobstep) ((rocm_utilization_percentage) * on (instance) group_left(jobid,jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -11088,7 +10998,6 @@
               },
               "editorMode": "code",
               "expr": "timestamp(count by (jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -11108,8 +11017,7 @@
                 "reducers": [
                   "mean"
                 ]
-              },
-              "topic": "series"
+              }
             },
             {
               "filter": {
@@ -11194,7 +11102,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -11341,7 +11248,6 @@
                 },
                 "inspect": false
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -11442,7 +11348,6 @@
               },
               "editorMode": "code",
               "expr": "avg by (jobstep) ((rocm_vram_used_percentage) * on (instance) group_left(jobid,jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -11455,7 +11360,6 @@
               },
               "editorMode": "code",
               "expr": "max by (jobstep) ((rocm_vram_used_percentage) * on (instance) group_left(jobid,jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -11468,7 +11372,6 @@
               },
               "editorMode": "code",
               "expr": "timestamp(count by (jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -11488,8 +11391,7 @@
                 "reducers": [
                   "mean"
                 ]
-              },
-              "topic": "series"
+              }
             },
             {
               "filter": {
@@ -11574,7 +11476,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -11706,7 +11607,6 @@
             "type": "prometheus",
             "uid": "$source"
           },
-          "description": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -11719,12 +11619,12 @@
                 },
                 "inspect": false
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -11827,7 +11727,6 @@
               },
               "editorMode": "code",
               "expr": "avg by (jobstep) ((rocm_average_socket_power_watts) * on (instance) group_left(jobid,jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -11840,7 +11739,6 @@
               },
               "editorMode": "code",
               "expr": "max by (jobstep) ((rocm_average_socket_power_watts) * on (instance) group_left(jobid,jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -11853,7 +11751,6 @@
               },
               "editorMode": "code",
               "expr": "timestamp(count by (jobstep) (rmsjob_info{jobid=\"$jobid\",jobstep!=\"-1\"} > 0))",
-              "hide": false,
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -11873,8 +11770,7 @@
                 "reducers": [
                   "mean"
                 ]
-              },
-              "topic": "series"
+              }
             },
             {
               "filter": {
@@ -11959,12 +11855,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -12093,7 +11989,7 @@
         "x": 0,
         "y": 47
       },
-      "id": 177,
+      "id": 212,
       "panels": [
         {
           "datasource": {
@@ -12105,7 +12001,6 @@
               "color": {
                 "mode": "fixed"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -12115,8 +12010,7 @@
                   }
                 ]
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 2,
@@ -12173,7 +12067,6 @@
               "color": {
                 "mode": "fixed"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -12183,8 +12076,7 @@
                   }
                 ]
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 2,
@@ -12241,7 +12133,6 @@
               "color": {
                 "mode": "fixed"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -12251,8 +12142,7 @@
                   }
                 ]
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 2,
@@ -12309,7 +12199,6 @@
               "color": {
                 "mode": "fixed"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -12320,8 +12209,7 @@
                 ]
               },
               "unit": "s"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 2,
@@ -12378,7 +12266,6 @@
               "color": {
                 "mode": "fixed"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -12389,8 +12276,7 @@
                 ]
               },
               "unit": "s"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 2,
@@ -12447,7 +12333,6 @@
               "color": {
                 "mode": "fixed"
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -12457,8 +12342,7 @@
                   }
                 ]
               }
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 2,
@@ -12549,7 +12433,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -12564,8 +12447,7 @@
                 ]
               },
               "unit": "s"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
@@ -12597,7 +12479,6 @@
               },
               "editorMode": "code",
               "expr": "avg by (collector) (omnistat_perf_runtime_seconds{collector=\"total\"} * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "instant": false,
               "legendFormat": "Total [average]",
               "range": true,
@@ -12610,7 +12491,6 @@
               },
               "editorMode": "code",
               "expr": "max by (collector) (omnistat_perf_runtime_seconds{collector=\"total\"} * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "instant": false,
               "legendFormat": "Total [max]",
               "range": true,
@@ -12623,7 +12503,6 @@
               },
               "editorMode": "code",
               "expr": "avg by (collector) (omnistat_perf_runtime_seconds{collector!=\"total\"} * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "instant": false,
               "legendFormat": "Collector: {{collector}} [average]",
               "range": true,
@@ -12636,7 +12515,6 @@
               },
               "editorMode": "code",
               "expr": "max by (collector) (omnistat_perf_runtime_seconds{collector!=\"total\"} * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "instant": false,
               "legendFormat": "Collector: {{collector}} [max]",
               "range": true,
@@ -12690,7 +12568,6 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -12705,8 +12582,7 @@
                 ]
               },
               "unit": "s"
-            },
-            "overrides": []
+            }
           },
           "gridPos": {
             "h": 8,
@@ -12738,7 +12614,6 @@
               },
               "editorMode": "code",
               "expr": "avg(omnistat_perf_push_seconds * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "instant": false,
               "legendFormat": "Push [average]",
               "range": true,
@@ -12751,7 +12626,6 @@
               },
               "editorMode": "code",
               "expr": "avg(omnistat_perf_push_seconds * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "instant": false,
               "interval": "",
               "legendFormat": "Push [max]",
@@ -12776,7 +12650,6 @@
               },
               "editorMode": "code",
               "expr": "max(omnistat_perf_push_background_seconds * on (instance) group_left() rmsjob_info{jobid=\"$jobid\"})",
-              "hide": false,
               "legendFormat": "Background Push [max]",
               "range": true,
               "refId": "Background Max"
@@ -12793,28 +12666,32 @@
   "preload": false,
   "refresh": "",
   "schemaVersion": 42,
-  "tags": [],
   "templating": {
     "list": [
       {
         "allowCustomValue": false,
         "hide": 2,
         "includeAll": false,
+        "multi": false,
         "name": "source",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "type": "datasource"
       },
       {
+        "allowCustomValue": true,
         "datasource": {
           "type": "prometheus",
           "uid": "${source}"
         },
         "definition": "label_values(rmsjob_info,jobid)",
+        "hide": 0,
         "includeAll": false,
         "label": "Job ID",
+        "multi": false,
         "name": "jobid",
         "options": [],
         "query": {
@@ -12824,16 +12701,21 @@
         },
         "refresh": 1,
         "regex": "",
-        "sort": 8,
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": 0,
         "type": "query"
       },
       {
+        "allowCustomValue": true,
         "current": {
           "text": "5s",
           "value": "5s"
         },
+        "hide": 0,
         "includeAll": false,
         "label": "Resolution",
+        "multi": false,
         "name": "interval",
         "options": [
           {
@@ -12873,7 +12755,9 @@
           }
         ],
         "query": "0.1s,0.5s,1s,5s,15s,30s,60s",
-        "type": "custom"
+        "skipUrlSync": false,
+        "type": "custom",
+        "valuesFormat": "csv"
       },
       {
         "allowCustomValue": false,
@@ -12885,6 +12769,7 @@
         "hide": 2,
         "includeAll": false,
         "label": "Sampling interval",
+        "multi": false,
         "name": "sampling_interval",
         "options": [],
         "query": {
@@ -12894,6 +12779,9 @@
         },
         "refresh": 2,
         "regex": "/interval_secs=\"([^\"]*)\"/",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": 0,
         "type": "query"
       },
       {
@@ -12920,6 +12808,8 @@
         },
         "refresh": 2,
         "regex": "/.*name=\"([^\"]*).*/",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
         "sort": 1,
         "type": "query"
       },
@@ -12947,6 +12837,8 @@
         },
         "refresh": 2,
         "regex": "/.*name=\"([^\"]*).*/",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
         "sort": 1,
         "type": "query"
       },
@@ -12974,6 +12866,9 @@
         },
         "refresh": 2,
         "regex": "/.*kernel=\"([^\"]*).*/",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": 0,
         "type": "query"
       }
     ]
@@ -12983,9 +12878,8 @@
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "",
+  "timezone": "browser",
   "title": "Job - Source",
   "uid": "fdqo0h2s2drswe-source",
-  "version": 1,
-  "weekStart": ""
+  "version": 1
 }


### PR DESCRIPTION
Kernels with single dispatches may produce sparse time series where Prometheus's `increase()` function generates floating-point extrapolation artifacts. This caused display issues in some kernel panels.

Fix:
- Add value mappings on the Min and Max columns to display "-" when values are very large
- Filter by both duration and number of dispatches > 0
- Only show kernel durations > 0