### PR TITLE
improve process based I/O monitoring in user-mode

### DIFF
--- a/misc/omnistat-ornl
+++ b/misc/omnistat-ornl
@@ -28,7 +28,7 @@
 setup_env() {
     # setup local env
     module try-load cray-python/3.11.5
-    module try-load rocm/6.4.1
+    module try-load rocm/7.2.0
     module use /sw/frontier/amdsw/modulefiles
     if [[ -n ${OMNISTAT_WRAPPER_VERSION} ]];then
 	module try-load omnistat/${OMNISTAT_WRAPPER_VERSION}

--- a/omnistat/collector_host.py
+++ b/omnistat/collector_host.py
@@ -92,11 +92,11 @@ class HOST(Collector):
                     self.__proc_io_cmds_exclude = config["omnistat.collectors.host"].get("proc_io_cmds_exclude")
                     self.__proc_io_cmds_exclude = re.split(r",\s*", self.__proc_io_cmds_exclude)
                     logging.debug("--> overriding default proc_io_cmd_exclude_list...")
+        self.__mode = config["omnistat.internal"]["mode"]
 
     def registerMetrics(self):
         """Register metrics of interest"""
 
-        # logging.info("Runtime options:")
         logging.info("cpu_load_sampling_interval: %.4f secs" % self.__cpu_load_sampling_interval)
         logging.info("enable_proc_io_stats: %s" % str(self.__enable_proc_io_stats))
         if self.__enable_proc_io_stats:
@@ -173,6 +173,8 @@ class HOST(Collector):
                 else:
                     self.__metrics[metric] = Gauge(self.__prefix + metric, description)
                 logging.info("--> [registered] %s (gauge)" % (self.__prefix + metric))
+
+
 
         # --
         # CPU oriented metrics
@@ -285,6 +287,22 @@ class HOST(Collector):
         else:
             logging.warning("--> no local disk devices found to track")
 
+        # user-mode: cache existing list of user processes at init time to filter them out from further monitoring; we assume only new PIDs 
+        # that appear after the collector starts are relevant to monitor (and avoids parent resource manager processes which can 
+        # lead to duplicate counting)
+
+        if self.__enable_proc_io_stats:
+            if self.__mode == "user":
+                self.__existing_pids = set()
+                for pid in os.listdir("/proc"):
+                    # restrict to running user
+                    proc_dir = os.path.join("/proc", pid)
+                    stat_info = os.stat(proc_dir)
+                    proc_uid = stat_info.st_uid
+                    if pid.isdigit() and proc_uid == os.getuid():
+                        self.__existing_pids.add(int(pid))
+                logging.info(f"--> cached {len(self.__existing_pids)} existing user PIDs to filter from I/O monitoring")
+
     def updateMetrics(self):
         """Update registered metrics of interest"""
 
@@ -379,6 +397,11 @@ class HOST(Collector):
             if not entry.isdigit():
                 continue
             pid = int(entry)
+
+            if self.__mode == "user":
+                # In user-mode, only monitor processes that started after the collector
+                if pid in self.__existing_pids:
+                    continue
 
             proc_dir = f"/proc/{pid}"
             try:

--- a/omnistat/collector_host.py
+++ b/omnistat/collector_host.py
@@ -174,8 +174,6 @@ class HOST(Collector):
                     self.__metrics[metric] = Gauge(self.__prefix + metric, description)
                 logging.info("--> [registered] %s (gauge)" % (self.__prefix + metric))
 
-
-
         # --
         # CPU oriented metrics
         # --
@@ -287,8 +285,8 @@ class HOST(Collector):
         else:
             logging.warning("--> no local disk devices found to track")
 
-        # user-mode: cache existing list of user processes at init time to filter them out from further monitoring; we assume only new PIDs 
-        # that appear after the collector starts are relevant to monitor (and avoids parent resource manager processes which can 
+        # user-mode: cache existing list of user processes at init time to filter them out from further monitoring; we assume only new PIDs
+        # that appear after the collector starts are relevant to monitor (and avoids parent resource manager processes which can
         # lead to duplicate counting)
 
         if self.__enable_proc_io_stats:

--- a/omnistat/config/omnistat.ornl
+++ b/omnistat/config/omnistat.ornl
@@ -15,7 +15,7 @@ enable_vendor_counters = True
 enable_kernel_trace = False
 
 ## Path to local ROCM install to access SMI library
-rocm_path = /opt/rocm-6.4.1
+rocm_path = /opt/rocm-7.2.0
 
 ## List of IPs allowed to query the collector (comma separated). By
 ## default, access will be restricted to the localhost (127.0.0.1).
@@ -26,6 +26,10 @@ allowed_ips = 127.0.0.1, 0.0.0.0
 
 host_skip = "login.*"
 enable_annotations = True
+
+[omnistat.collectors.host]
+enable_proc_io_stats = True
+cpu_load_sampling_interval = 0.05
 
 [omnistat.collectors.rocprofiler]
 profile = default

--- a/omnistat/config/omnistat.ornl.external
+++ b/omnistat/config/omnistat.ornl.external
@@ -15,7 +15,7 @@ enable_vendor_counters = True
 enable_kernel_trace = False
 
 ## Path to local ROCM install to access SMI library
-rocm_path = /opt/rocm-6.4.1
+rocm_path = /opt/rocm-7.2.0
 
 ## List of IPs allowed to query the collector (comma separated). By
 ## default, access will be restricted to the localhost (127.0.0.1).
@@ -26,6 +26,10 @@ allowed_ips = 127.0.0.1, 0.0.0.0
 
 host_skip = "login.*"
 enable_annotations = True
+
+[omnistat.collectors.host]
+enable_proc_io_stats = True
+cpu_load_sampling_interval = 0.05
 
 [omnistat.collectors.rocprofiler]
 profile = default


### PR DESCRIPTION
This PR updates existing  logic in user-mode execution when optional pid-based I/O monitoring is enabled. The motivation is to avoid duplicating I/O counts from parent resource manager processes (e.g. `slurm_script`) by tracking only process I/O initiated **after** Omnistat data collection is initiated. This change caches existing user PIDs at startup so they can be filtered during collection.
