### PR TITLE
introduce external (3rd party) data collector

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Additional python packages
         run: pip3 install -r docs/requirements-docs.txt
       - name: Setup Pages

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: find-bytecode
       run: |
         set +e

--- a/.github/workflows/test-gpus.yml
+++ b/.github/workflows/test-gpus.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           source omnistat_venv/bin/activate
           srun -N 1 -J omnistat -p $CI_QUEUE -t 00:10:00 \
-            pytest -v --junitxml=results.xml test/test_collectors.py test/test_endpoint_collectors.py test/test_rocprofiler_collectors.py test/test_external_collector.py
+            pytest -v --junitxml=results.xml test/test_collectors.py test/test_endpoint_collectors.py test/test_external_collector.py
 
 ##       - name: Test Report
 ##         uses: dorny/test-reporter@v2

--- a/.github/workflows/test-gpus.yml
+++ b/.github/workflows/test-gpus.yml
@@ -30,7 +30,7 @@ jobs:
               exit 1
            fi
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Create virtual environment
         run: |

--- a/.github/workflows/test-gpus.yml
+++ b/.github/workflows/test-gpus.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           source omnistat_venv/bin/activate
           srun -N 1 -J omnistat -p $CI_QUEUE -t 00:10:00 \
-            pytest -v --junitxml=results.xml test/test_collectors.py test/test_endpoint_collectors.py
+            pytest -v --junitxml=results.xml test/test_collectors.py test/test_endpoint_collectors.py test/test_rocprofiler_collectors.py test/test_external_collector.py
 
 ##       - name: Test Report
 ##         uses: dorny/test-reporter@v2

--- a/.github/workflows/test-gpus.yml
+++ b/.github/workflows/test-gpus.yml
@@ -71,7 +71,7 @@ jobs:
 ##           path: results.xml
 
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@v6
         if: ${{ !cancelled() }}
         with:
           include_passed: 'true'

--- a/.github/workflows/test-local-usermode.yml
+++ b/.github/workflows/test-local-usermode.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Download VictoriaMetrics (v1.140.0)
         run: |

--- a/.github/workflows/test-mi325.yml
+++ b/.github/workflows/test-mi325.yml
@@ -52,7 +52,7 @@ jobs:
           amd-smi metric -E
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Update git directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/test-mi325.yml
+++ b/.github/workflows/test-mi325.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           source omnistat_venv/bin/activate
           su - ubuntu -c "sleep 300 &"
-          pytest -s -v --junitxml=results.xml test/test_collectors.py test/test_endpoint_collectors.py
+          pytest -s -v --junitxml=results.xml test/test_collectors.py test/test_endpoint_collectors.py test/test_external_collector.py
 
 ##       - name: Test Report
 ##         uses: dorny/test-reporter@v2

--- a/.github/workflows/test-mi325.yml
+++ b/.github/workflows/test-mi325.yml
@@ -97,7 +97,7 @@ jobs:
 ##           path: results.xml
 
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@v6
         if: ${{ !cancelled() }}
         with:
           include_passed: 'true'

--- a/.github/workflows/test-tsdb.yml
+++ b/.github/workflows/test-tsdb.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Start containerized environment
         run: docker compose -f test/docker/victoriametrics/compose.yaml up -d
       - name: Wait for Victoria Metrics

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install dependencies
         run: pip3 install -r requirements.txt -r test/requirements.txt
       - name: Run unit tests

--- a/.github/workflows/test-user-push.yml
+++ b/.github/workflows/test-user-push.yml
@@ -13,7 +13,7 @@ jobs:
         execution: [ source, package ]
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Comment out GPU devices (not available in GitHub)
         run: sed -i "/devices:/,+2 s/^/#/" test/docker/slurm/compose.yaml
       - name: Disable SMI collector (won't work in GitHub)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         execution: [ source, package ]
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Comment out GPU devices (not available in GitHub)
         run: sed -i "/devices:/,+2 s/^/#/" test/docker/slurm/compose.yaml
       - name: Disable SMI collector (won't work in GitHub)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -356,14 +356,14 @@ will be automatically removed from Omnistat tracking so metrics can be dynamical
 
 **Collector**: `enable_external`
 <br/>
-**Collector options**: `script`, `timeout`
+**Collector options**: `script`, `timeout_secs`
 
 ### Configuration
 
 The external collector is enabled by setting `enable_external = True` in the
 `[omnistat.collectors]` section. Collector options are configured in a
 separate `[omnistat.collectors.external]` section where `script` specifies
-the path to the executable and `timeout` (default: 10 seconds) controls how
+the path to the executable and `timeout_secs` (default: 10 seconds) controls how
 long Omnistat will wait for the script to complete before discarding its
 output.
 
@@ -376,7 +376,7 @@ output.
 
     [omnistat.collectors.external]
     script = /path/to/my_metrics.sh
-    timeout = 10
+    timeout_secs = 10
 ```
 
 ### Script output format

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -21,6 +21,9 @@ Note that Omnistat metrics generally fall into one of the two following types:
   and include a `card` label to distinguish between them. These metric types are denoted
   with a *GPU Metric* heading.
 
+In addition, an optional [External](#external) data collector is available to
+ingest additional site-specific metrics not included directly in Omnistat.
+
 <hr style="border: 1px solid black;">
 
 ## ROCm
@@ -333,3 +336,83 @@ Slingshot.
 | :-------------------------- | :----------------------------------- |
 | `omnistat_network_tx_bytes` | Total bytes transmitted by network interface. Labels: `device_class`, `interface`. |
 | `omnistat_network_rx_bytes` | Total bytes received by network interface. Labels: `device_class`, `interface`. |
+
+<hr style="border: 1px solid black;">
+
+## External
+
+The external data collector provides a mechanism to incorporate custom,
+site-specific metrics into Omnistat by executing a user-provided script at each
+collection interval. The script is expected to write metrics to stdout in
+[Prometheus text exposition
+format](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format)
+(one metric per line). Metric names and labels are not fixed in advance --
+they are discovered dynamically from the script output at runtime.
+
+All metrics produced by the external script are automatically tagged with an
+`omnistat_external="1"` label to distinguish them from native Omnistat metrics.
+Any metric that is **not** present in the script output on a given invocation
+will be automatically removed from Omnistat tracking so metrics can be dynamically added/deleted via this method.
+
+**Collector**: `enable_external`
+<br/>
+**Collector options**: `script`, `timeout`
+
+### Configuration
+
+The external collector is enabled by setting `enable_external = True` in the
+`[omnistat.collectors]` section. Collector options are configured in a
+separate `[omnistat.collectors.external]` section where `script` specifies
+the path to the executable and `timeout` (default: 10 seconds) controls how
+long Omnistat will wait for the script to complete before discarding its
+output.
+
+```eval_rst
+.. code-block:: ini
+   :caption: Example configuration
+
+    [omnistat.collectors]
+    enable_external = True
+
+    [omnistat.collectors.external]
+    script = /path/to/my_metrics.sh
+    timeout = 10
+```
+
+### Script output format
+
+The script must print metrics to stdout using the following format:
+
+```
+metric_name value
+metric_name{label1="val1",label2="val2"} value
+```
+
+Lines beginning with `#` and empty lines are ignored.
+
+### Example
+
+The following example script emits free disk space metrics for multiple
+filesystems, using a label to distinguish between them.
+
+```eval_rst
+.. code-block:: bash
+   :caption: my_metrics.sh
+
+    #!/usr/bin/env bash
+    # Emit free space (bytes) for monitored filesystems
+    for fs in /home /scratch; do
+        free_bytes=$(df --output=avail -B1 "${fs}" | tail -1)
+        echo "site_disk_free_bytes{fs=\"${fs}\"} ${free_bytes}"
+    done
+```
+
+Running the script produces output that Omnistat parses directly:
+
+```eval_rst
+.. code-block:: console
+
+    $ ./my_metrics.sh
+    site_disk_free_bytes{fs="/home"} 524288000000
+    site_disk_free_bytes{fs="/scratch"} 1932735283200
+```

--- a/omnistat/collector_definitions.json
+++ b/omnistat/collector_definitions.json
@@ -69,6 +69,12 @@
             "class_name": "HOST"
         },
         {
+            "runtime_option": "enable_external",
+            "enabled_by_default": false,
+            "file": "omnistat.collector_external",
+            "class_name": "ExternalScript"
+        },
+        {
             "runtime_option": null,
             "enabled_by_default": true,
             "file": "omnistat.collector_info",

--- a/omnistat/collector_external.py
+++ b/omnistat/collector_external.py
@@ -46,8 +46,8 @@ Runtime configuration (omnistat.collectors.external section):
     script = /path/to/my/script.sh
     timeout = 10
 
-The script path is required; timeout defaults to 10 seconds.  All metric names
-are prefixed with "omnistat_" before registration.
+The script path is required; timeout defaults to 10 seconds.  Metric names are
+used verbatim; an "omnistat_external" label is added to each metric for identification.
 """
 
 import configparser

--- a/omnistat/collector_external.py
+++ b/omnistat/collector_external.py
@@ -73,7 +73,8 @@ class ExternalScript(Collector):
     def __init__(self, config: configparser.ConfigParser):
         logging.debug(f"Initializing {self.__class__.__name__} data collector")
 
-        self.__prefix = "omnistat_external_"
+        self.__prefix = ""
+        self.__collector_label = "omnistat_external"
         self.__metrics = {}
         self.__script = None
         self.__timeout = 10
@@ -170,6 +171,7 @@ class ExternalScript(Collector):
                 continue
 
             name, labels, value = parsed
+            labels["collector"] = self.__collector_label
             label_names = sorted(labels.keys())
             key = (name, tuple(label_names))
 

--- a/omnistat/collector_external.py
+++ b/omnistat/collector_external.py
@@ -182,9 +182,9 @@ class ExternalScript(Collector):
                 else:
                     self.__metrics[key] = Gauge(full_name, f"External metric: {name}")
                 if register:
-                    logging.info(f"--> [registered] {full_name} (gauge)")
+                    logging.info(f"--> [registered] {full_name} labels={label_names} (gauge)")
                 else:
-                    logging.debug(f"--> [registered late] {full_name} (gauge)")
+                    logging.debug(f"--> [registered late] {full_name} labels={label_names} (gauge)")
 
             gauge = self.__metrics[key]
             if label_names:

--- a/omnistat/collector_external.py
+++ b/omnistat/collector_external.py
@@ -126,9 +126,7 @@ class ExternalScript(Collector):
             return []
 
         if result.returncode != 0:
-            logging.warning(
-                f"ExternalScript: script exited with code {result.returncode}: {result.stderr.strip()}"
-            )
+            logging.warning(f"ExternalScript: script exited with code {result.returncode}: {result.stderr.strip()}")
 
         return result.stdout.splitlines()
 

--- a/omnistat/collector_external.py
+++ b/omnistat/collector_external.py
@@ -158,10 +158,10 @@ class ExternalScript(Collector):
         return name, labels, value
 
     def _update(self, register: bool):
-        """Run the script and either register or update metrics.
+        """Run the script and update metrics, registering any new ones on the fly.
 
         Args:
-            register (bool): True on first call to create Gauge objects; False to just set values.
+            register (bool): True on first call (logs at info level); False on subsequent calls (logs at debug level).
         """
         lines = self._run_script()
 
@@ -175,18 +175,16 @@ class ExternalScript(Collector):
             label_names = sorted(labels.keys())
             key = (name, tuple(label_names))
 
-            if register:
-                if key not in self.__metrics:
-                    full_name = self.__prefix + name
-                    if label_names:
-                        self.__metrics[key] = Gauge(full_name, f"External metric: {name}", labelnames=label_names)
-                    else:
-                        self.__metrics[key] = Gauge(full_name, f"External metric: {name}")
+            if key not in self.__metrics:
+                full_name = self.__prefix + name
+                if label_names:
+                    self.__metrics[key] = Gauge(full_name, f"External metric: {name}", labelnames=label_names)
+                else:
+                    self.__metrics[key] = Gauge(full_name, f"External metric: {name}")
+                if register:
                     logging.info(f"--> [registered] {full_name} (gauge)")
-            else:
-                if key not in self.__metrics:
-                    logging.warning(f"ExternalScript: metric '{name}' appeared after registration; skipping")
-                    continue
+                else:
+                    logging.debug(f"--> [registered late] {full_name} (gauge)")
 
             gauge = self.__metrics[key]
             if label_names:

--- a/omnistat/collector_external.py
+++ b/omnistat/collector_external.py
@@ -75,6 +75,7 @@ class ExternalScript(Collector):
 
         self.__prefix = ""
         self.__metrics = {}
+        self.__metric_instances = {}  # key -> list of label-value tuples (in label_names order)
         self.__script = None
         self.__timeout = 10
 
@@ -159,10 +160,34 @@ class ExternalScript(Collector):
     def _update(self, register: bool):
         """Run the script and update metrics, registering any new ones on the fly.
 
+        At the start of each non-registration update, all previously set label
+        combinations are removed from their gauges before the script output is
+        applied.  If the script produces no output (e.g. the underlying command
+        segfaults or the device is unavailable), no values are re-added and the
+        metrics disappear from the /metrics endpoint.  VictoriaMetrics / Prometheus
+        then marks them stale rather than holding the last known value.
+
         Args:
             register (bool): True on first call (logs at info level); False on subsequent calls (logs at debug level).
         """
         lines = self._run_script()
+
+        # Clear all previously emitted label combinations so that metrics from a
+        # failed or empty script run don't linger as stale values.
+        if not register:
+            for key, instances in self.__metric_instances.items():
+                gauge = self.__metrics.get(key)
+                if gauge is None:
+                    continue
+                for label_values in instances:
+                    try:
+                        if label_values:
+                            gauge.remove(*label_values)
+                        else:
+                            gauge.set(float("nan"))
+                    except KeyError:
+                        pass
+            self.__metric_instances.clear()
 
         for line in lines:
             parsed = self._parse_line(line)
@@ -187,7 +212,10 @@ class ExternalScript(Collector):
                     logging.debug(f"--> [registered late] {full_name}{label_str} (gauge)")
 
             gauge = self.__metrics[key]
+            label_values = tuple(labels[k] for k in label_names)
             if label_names:
                 gauge.labels(**labels).set(value)
             else:
                 gauge.set(value)
+
+            self.__metric_instances.setdefault(key, []).append(label_values)

--- a/omnistat/collector_external.py
+++ b/omnistat/collector_external.py
@@ -74,7 +74,6 @@ class ExternalScript(Collector):
         logging.debug(f"Initializing {self.__class__.__name__} data collector")
 
         self.__prefix = ""
-        self.__collector_label = "omnistat_external"
         self.__metrics = {}
         self.__script = None
         self.__timeout = 10
@@ -171,7 +170,7 @@ class ExternalScript(Collector):
                 continue
 
             name, labels, value = parsed
-            labels["collector"] = self.__collector_label
+            labels["omnistat_external"] = "1"
             label_names = sorted(labels.keys())
             key = (name, tuple(label_names))
 
@@ -181,10 +180,11 @@ class ExternalScript(Collector):
                     self.__metrics[key] = Gauge(full_name, f"External metric: {name}", labelnames=label_names)
                 else:
                     self.__metrics[key] = Gauge(full_name, f"External metric: {name}")
+                label_str = "{" + ",".join(f'{k}="{labels[k]}"' for k in label_names) + "}"
                 if register:
-                    logging.info(f"--> [registered] {full_name} labels={label_names} (gauge)")
+                    logging.info(f"--> [registered] {full_name}{label_str} (gauge)")
                 else:
-                    logging.debug(f"--> [registered late] {full_name} labels={label_names} (gauge)")
+                    logging.debug(f"--> [registered late] {full_name}{label_str} (gauge)")
 
             gauge = self.__metrics[key]
             if label_names:

--- a/omnistat/collector_external.py
+++ b/omnistat/collector_external.py
@@ -1,0 +1,193 @@
+# -------------------------------------------------------------------------------
+# MIT License
+#
+# Copyright (c) 2023 - 2026 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# -------------------------------------------------------------------------------
+
+"""External script metric collector
+
+Forks a user-defined script at each polling interval and parses its stdout to
+populate Prometheus gauge metrics.  This allows site-specific metrics to be
+injected into Omnistat without modifying core collector code.
+
+Script output format (one metric per line):
+
+    <metric_name> <float_value>
+    <metric_name>{<label_key>="<label_value>"[,...]} <float_value>
+
+Lines that are empty or begin with '#' are ignored.
+
+Example script output:
+
+    # site custom metrics
+    site_job_queue_depth 42
+    site_scratch_free_bytes{fs="/scratch"} 1.23e+12
+
+Runtime configuration (omnistat.collectors.external section):
+
+    script = /path/to/my/script.sh
+    timeout = 10
+
+The script path is required; timeout defaults to 10 seconds.  All metric names
+are prefixed with "omnistat_" before registration.
+"""
+
+import configparser
+import logging
+import re
+import shlex
+import subprocess
+import sys
+
+from prometheus_client import Gauge
+
+from omnistat.collector_base import Collector
+
+# Matches:  name{k="v",...}  value   OR   name  value
+_LINE_RE = re.compile(
+    r"^(?P<name>[a-zA-Z_][a-zA-Z0-9_]*)(?P<labels>\{[^}]*\})?\s+(?P<value>[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?)\s*$"
+)
+# Matches individual label pairs inside {…}
+_LABEL_RE = re.compile(r'([a-zA-Z_][a-zA-Z0-9_]*)="([^"]*)"')
+
+
+class ExternalScript(Collector):
+    def __init__(self, config: configparser.ConfigParser):
+        logging.debug(f"Initializing {self.__class__.__name__} data collector")
+
+        self.__prefix = "omnistat_external_"
+        self.__metrics = {}
+        self.__script = None
+        self.__timeout = 10
+
+        if not config.has_section("omnistat.collectors.external"):
+            logging.error("[ERROR] ExternalScript collector requires an [omnistat.collectors.external] config section")
+            sys.exit(1)
+
+        section = config["omnistat.collectors.external"]
+
+        if not section.get("script"):
+            logging.error("[ERROR] ExternalScript collector requires 'script' option in [omnistat.collectors.external]")
+            sys.exit(1)
+
+        self.__script = section.get("script").strip()
+        self.__timeout = section.getint("timeout", 10)
+
+    def registerMetrics(self):
+        logging.info(f"script: {self.__script}")
+        logging.info(f"timeout: {self.__timeout} sec")
+        # Metrics are registered dynamically on first updateMetrics() call
+        # because we don't know the metric names until the script runs.
+        self._update(register=True)
+
+    def updateMetrics(self):
+        self._update(register=False)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+
+    def _run_script(self):
+        """Fork the configured script and return its stdout lines.
+
+        Returns:
+            list[str]: Lines of output, or empty list on error.
+        """
+        try:
+            result = subprocess.run(
+                shlex.split(self.__script),
+                capture_output=True,
+                text=True,
+                timeout=self.__timeout,
+            )
+        except subprocess.TimeoutExpired:
+            logging.warning(f"ExternalScript: script timed out after {self.__timeout}s: {self.__script}")
+            return []
+        except Exception as e:
+            logging.warning(f"ExternalScript: failed to run script: {e}")
+            return []
+
+        if result.returncode != 0:
+            logging.warning(
+                f"ExternalScript: script exited with code {result.returncode}: {result.stderr.strip()}"
+            )
+
+        return result.stdout.splitlines()
+
+    def _parse_line(self, line):
+        """Parse one line of script output.
+
+        Returns:
+            tuple: (metric_name, label_dict, float_value) or None if unparseable.
+        """
+        line = line.strip()
+        if not line or line.startswith("#"):
+            return None
+
+        m = _LINE_RE.match(line)
+        if not m:
+            logging.warning(f"ExternalScript: skipping unparseable line: {line!r}")
+            return None
+
+        name = m.group("name")
+        value = float(m.group("value"))
+
+        labels = {}
+        if m.group("labels"):
+            for lm in _LABEL_RE.finditer(m.group("labels")):
+                labels[lm.group(1)] = lm.group(2)
+
+        return name, labels, value
+
+    def _update(self, register: bool):
+        """Run the script and either register or update metrics.
+
+        Args:
+            register (bool): True on first call to create Gauge objects; False to just set values.
+        """
+        lines = self._run_script()
+
+        for line in lines:
+            parsed = self._parse_line(line)
+            if parsed is None:
+                continue
+
+            name, labels, value = parsed
+            label_names = sorted(labels.keys())
+            key = (name, tuple(label_names))
+
+            if register:
+                if key not in self.__metrics:
+                    full_name = self.__prefix + name
+                    if label_names:
+                        self.__metrics[key] = Gauge(full_name, f"External metric: {name}", labelnames=label_names)
+                    else:
+                        self.__metrics[key] = Gauge(full_name, f"External metric: {name}")
+                    logging.info(f"--> [registered] {full_name} (gauge)")
+            else:
+                if key not in self.__metrics:
+                    logging.warning(f"ExternalScript: metric '{name}' appeared after registration; skipping")
+                    continue
+
+            gauge = self.__metrics[key]
+            if label_names:
+                gauge.labels(**labels).set(value)
+            else:
+                gauge.set(value)

--- a/omnistat/collector_external.py
+++ b/omnistat/collector_external.py
@@ -44,9 +44,9 @@ Example script output:
 Runtime configuration (omnistat.collectors.external section):
 
     script = /path/to/my/script.sh
-    timeout = 10
+    timeout_secs = 10
 
-The script path is required; timeout defaults to 10 seconds.  Metric names are
+The script path is required; timeout_secs defaults to 10 seconds.  Metric names are
 used verbatim; an "omnistat_external" label is added to each metric for identification.
 """
 
@@ -90,7 +90,7 @@ class ExternalScript(Collector):
             sys.exit(1)
 
         self.__script = section.get("script").strip()
-        self.__timeout = section.getint("timeout", 10)
+        self.__timeout = section.getint("timeout_secs", 10)
 
     def registerMetrics(self):
         logging.info(f"script: {self.__script}")

--- a/omnistat/config/omnistat.default
+++ b/omnistat/config/omnistat.default
@@ -10,6 +10,7 @@ enable_network = True
 enable_vendor_counters = False
 enable_host_metrics = True
 enable_kernel_trace = False
+enable_external = False
 
 ## Path to local ROCM install to access SMI library
 rocm_path = /opt/rocm
@@ -98,6 +99,11 @@ counters = [
 [omnistat.collectors.rocprofiler.cache_l2_hitrate]
 sampling_mode = constant
 counters = ["TCC_HIT_sum", "TCC_MISS_sum"]
+
+## Path to external data collector
+[omnistat.collectors.external]
+script = /path/to/my_metrics.sh
+timeout = 10
 
 [omnistat.query]
 

--- a/omnistat/config/omnistat.default
+++ b/omnistat/config/omnistat.default
@@ -103,7 +103,7 @@ counters = ["TCC_HIT_sum", "TCC_MISS_sum"]
 ## Path to external data collector
 [omnistat.collectors.external]
 script = /path/to/my_metrics.sh
-timeout = 10
+timeout_secs = 10
 
 [omnistat.query]
 

--- a/test/scripts/external_collector.sh
+++ b/test/scripts/external_collector.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# -------------------------------------------------------------------------------
+# MIT License
+#
+# Copyright (c) 2023 - 2026 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# -------------------------------------------------------------------------------
+#
+# Stateful metric generator for external collector tests.
+#
+# Usage:
+#   external_collector.sh -init <statefile>    # reset state (counter=0)
+#   external_collector.sh <statefile>          # emit metrics for current run, then increment
+#   external_collector.sh                      # emit default metric (no state tracking)
+
+STATEFILE="$1"
+
+# Handle -help: print usage
+if [ "$1" = "-h" ] || [ "$1" = "-help" ] || [ "$1" = "--help" ]; then
+    echo "Usage:"
+    echo "  $(basename "$0") -init <statefile>   Reset state (counter=0)"
+    echo "  $(basename "$0") <statefile>          Emit metrics for current run, then increment"
+    echo "  $(basename "$0")                      Emit default metric (no state tracking)"
+    exit 0
+fi
+
+# Handle -init: reset counter to 0
+if [ "$1" = "-init" ]; then
+    echo 0 > "$2"
+    exit 0
+fi
+
+# No argument: emit a static default metric
+if [ -z "$STATEFILE" ]; then
+    echo 'my_snazzy_metric{my_snazzy_label="omnistat_for_the_win"} 42'
+    exit 0
+fi
+
+# Read current run counter (default to 0 if missing)
+RUN=0
+if [ -f "$STATEFILE" ]; then
+    RUN=$(cat "$STATEFILE")
+fi
+
+# Emit metrics based on run number
+case $RUN in
+    0)
+        echo 'my_snazzy_metric{my_snazzy_label="omnistat_for_the_win"} 42'
+        ;;
+    1)
+        echo 'my_snazzy_metric2{my_snazzy_label2="rocks"} 43'
+        ;;
+    2)
+        echo 'my_snazzy_metric3{my_snazzy_label3="ftw"} 44'
+        echo 'my_snazzy_metric3b{my_snazzy_label3b="bonus"} 45'
+        ;;
+    *)
+        echo 'my_snazzy_metric{my_snazzy_label="omnistat_for_the_win"} 42'
+        ;;
+esac
+
+# Increment counter
+echo $((RUN + 1)) > "$STATEFILE"

--- a/test/test_external_collector.py
+++ b/test/test_external_collector.py
@@ -1,0 +1,125 @@
+# -------------------------------------------------------------------------------
+# MIT License
+#
+# Copyright (c) 2023 - 2026 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# -------------------------------------------------------------------------------
+
+import os
+import subprocess
+import tempfile
+
+import pytest
+
+from test.test_collectors import OmnistatTestServer
+
+EXTERNAL_COLLECTOR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "scripts", "external_collector.sh")
+
+
+class ExternalTestServer(OmnistatTestServer):
+    """Omnistat server with only the external collector enabled.
+
+    The server runs the stateful helper script that emits different metrics
+    on each invocation, driven by a counter in a state file.
+    """
+
+    def __init__(self, statefile):
+        self.statefile = statefile
+
+        config_sections = {
+            "omnistat.collectors.external": {
+                "script": f"{EXTERNAL_COLLECTOR} {statefile}",
+                "timeout": "5",
+            },
+        }
+        super().__init__(["external"], config_sections=config_sections)
+
+        # Reset counter after server startup so that scrapes from
+        # wait_for_server() don't consume test runs.
+        subprocess.run([EXTERNAL_COLLECTOR, "-init", statefile], check=True)
+
+    def get(self):
+        """Scrape /metrics and return {name: {frozenset(labels): value}}."""
+        results = {}
+        for family in super().get():
+            for sample in family.samples:
+                key = frozenset(sample.labels.items())
+                results.setdefault(sample.name, {})[key] = sample.value
+        return results
+
+
+@pytest.fixture(scope="class")
+def external_server(request):
+    """Start a single ExternalTestServer and perform 3 sequential scrapes."""
+    fd, statefile = tempfile.mkstemp(suffix=".state")
+    os.close(fd)
+    server = ExternalTestServer(statefile)
+
+    # Perform all scrapes up front so tests can reference them by index
+    request.cls.scrapes = [server.get(), server.get(), server.get()]
+
+    yield server
+
+    server.stop()
+    if os.path.exists(statefile):
+        os.unlink(statefile)
+
+
+@pytest.mark.usefixtures("external_server")
+class TestExternalCollector:
+    def test_single_metric(self):
+        """Scrape 1: verify single metric with known value and label."""
+        metrics = self.scrapes[0]
+        assert "my_snazzy_metric" in metrics, f"Missing my_snazzy_metric, got: {list(metrics.keys())}"
+        for label_set, value in metrics["my_snazzy_metric"].items():
+            labels = dict(label_set)
+            assert labels.get("omnistat_external") == "1", f"Missing omnistat_external label: {labels}"
+            assert labels.get("my_snazzy_label") == "omnistat_for_the_win"
+            assert value == 42.0
+
+    def test_metric_change(self):
+        """Scrape 2: verify new metric replaces previous one."""
+        metrics = self.scrapes[1]
+        assert "my_snazzy_metric2" in metrics, f"Missing my_snazzy_metric2, got: {list(metrics.keys())}"
+        assert "my_snazzy_metric" not in metrics, "my_snazzy_metric should have been removed"
+        for label_set, value in metrics["my_snazzy_metric2"].items():
+            labels = dict(label_set)
+            assert labels.get("omnistat_external") == "1"
+            assert labels.get("my_snazzy_label2") == "rocks"
+            assert value == 43.0
+
+    def test_multiple_metrics(self):
+        """Scrape 3: verify two new metrics replace previous one."""
+        metrics = self.scrapes[2]
+        assert "my_snazzy_metric2" not in metrics, "my_snazzy_metric2 should have been removed"
+
+        assert "my_snazzy_metric3" in metrics, f"Missing my_snazzy_metric3, got: {list(metrics.keys())}"
+        for label_set, value in metrics["my_snazzy_metric3"].items():
+            labels = dict(label_set)
+            assert labels.get("omnistat_external") == "1"
+            assert labels.get("my_snazzy_label3") == "ftw"
+            assert value == 44.0
+
+        assert "my_snazzy_metric3b" in metrics, f"Missing my_snazzy_metric3b, got: {list(metrics.keys())}"
+        for label_set, value in metrics["my_snazzy_metric3b"].items():
+            labels = dict(label_set)
+            assert labels.get("omnistat_external") == "1"
+            assert labels.get("my_snazzy_label3b") == "bonus"
+            assert value == 45.0

--- a/test/test_external_collector.py
+++ b/test/test_external_collector.py
@@ -46,7 +46,7 @@ class ExternalTestServer(OmnistatTestServer):
         config_sections = {
             "omnistat.collectors.external": {
                 "script": f"{EXTERNAL_COLLECTOR} {statefile}",
-                "timeout": "5",
+                "timeout_secs": "5",
             },
         }
         super().__init__(["external"], config_sections=config_sections)


### PR DESCRIPTION
This new external data collector provides a mechanism to incorporate custom, site-specific metrics into Omnistat by executing a user-provided script at each collection interval. The user-supplied script is expected to write metrics to stdout in [Prometheus text exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format) (one metric per line). Metric names and labels are not fixed in advance -- they are discovered dynamically from the script output at runtime.

#### Collector enablement: 

```
[omnistat.collectors]
enable_external = True
```

#### Runtime config controls:

```
[omnistat.collectors.external]
script = /path/to/my_metrics.sh
timeout_secs = 10
```

For example, the following script execution would define a file-system monitoring metric with two labels:

```
$ ./my_metrics.sh
site_disk_free_bytes{fs="/home"} 524288000000
site_disk_free_bytes{fs="/scratch"} 1932735283200
```