### PR TITLE
add rocm_energy_joules metric for energy accumulation

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -47,7 +47,7 @@ health and performance.
 | `rocm_vram_used_percentage`       | Memory utilization (%). |
 | `rocm_vram_total_bytes`           | Total GPU memory (bytes). |
 | `rocm_average_socket_power_watts` | Average socket power (W). |
-| `rocm_energy_joules`              | Cumulative energy consumption (J) - accumulated since GPU driver load. |
+| `rocm_energy_joules`              | Cumulative energy consumption (J). Data is accumulated since last GPU driver load. |
 | `rocm_sclk_clock_mhz`             | GPU clock speed (MHz). |
 | `rocm_mclk_clock_mhz`             | Memory clock speed (MHz). |
 | `rocm_temperature_celsius`        | GPU temperature (°C). Labels: `location`. |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -47,6 +47,7 @@ health and performance.
 | `rocm_vram_used_percentage`       | Memory utilization (%). |
 | `rocm_vram_total_bytes`           | Total GPU memory (bytes). |
 | `rocm_average_socket_power_watts` | Average socket power (W). |
+| `rocm_energy_joules`              | Cumulative energy consumption (J) - accumulated since GPU driver load. |
 | `rocm_sclk_clock_mhz`             | GPU clock speed (MHz). |
 | `rocm_mclk_clock_mhz`             | Memory clock speed (MHz). |
 | `rocm_temperature_celsius`        | GPU temperature (°C). Labels: `location`. |

--- a/omnistat/collector_amdsmi.py
+++ b/omnistat/collector_amdsmi.py
@@ -37,6 +37,7 @@ rocm_utilization_percentage{card="0"} 0.0
 rocm_vram_used_percentage{card="0"} 0.0
 rocm_vram_busy_percentage{card="0"} 22.0
 rocm_average_socket_power_watts{card="0"} 35.0
+rocm_energy_joules{card="0"} 2.6181130255356e+07
 rocm_mlck_clock_mhz{card="0"} 1200.0
 rocm_slck_clock_mhz{card="0"} 300.0
 """

--- a/omnistat/collector_amdsmi.py
+++ b/omnistat/collector_amdsmi.py
@@ -386,6 +386,13 @@ class AMDSMI(Collector):
                 self.__prefix + "power_cap_watts", "Max power cap of device (W)", labelnames=["card"]
             )
 
+        # Register energy metric
+        self.__GPUMetrics["energy_joules"] = Gauge(
+            self.__prefix + "energy_joules",
+            "Cumulative energy consumption (J)",
+            labelnames=["card"],
+        )
+
         if self.__cu_occupancy_monitoring:
             # Measure the number CUs in each GPU node ID (KFD internal GPU index),
             # and map it to KFD GPU indices.
@@ -478,6 +485,11 @@ class AMDSMI(Collector):
             if self.__power_cap_monitoring:
                 power_info = smi.amdsmi_get_power_cap_info(device)
                 self.__GPUMetrics["power_cap_watts"].labels(card=cardId).set(power_info["power_cap"] / 1000000)
+
+            # cumulative energy [micro Joules, converted to Joules]
+            energy_info = smi.amdsmi_get_energy_count(device)
+            energy_uJ = energy_info["energy_accumulator"] * energy_info["counter_resolution"]
+            self.__GPUMetrics["energy_joules"].labels(card=cardId).set(energy_uJ / 1000000.0)
 
             # CU occupancy
             if self.__cu_occupancy_monitoring:

--- a/omnistat/collector_rocmsmi.py
+++ b/omnistat/collector_rocmsmi.py
@@ -33,6 +33,7 @@ following example highlights example metrics for card 0:
 rocm_temperature_celsius{card="0",location="edge"} 41.0
 rocm_temperature_memory_celsius{card="0",location="hbm_0"} 46.0
 rocm_average_socket_power_watts{card="0"} 35.0
+rocm_energy_joules{card="0"} 2.6181130255356e+07
 rocm_sclk_clock_mhz{card="0"} 1502.0
 rocm_mclk_clock_mhz{card="0"} 1200.0
 rocm_vram_busy_percentage{card="0"} 22.0

--- a/omnistat/collector_rocmsmi.py
+++ b/omnistat/collector_rocmsmi.py
@@ -377,9 +377,7 @@ class ROCMSMI(Collector):
             self.__prefix + "average_socket_power_watts", "gauge", "Average Graphics Package Power (W)"
         )
         # energy
-        self.registerGPUMetric(
-            self.__prefix + "energy_joules", "gauge", "Cumulative energy consumption (J)"
-        )
+        self.registerGPUMetric(self.__prefix + "energy_joules", "gauge", "Cumulative energy consumption (J)")
         # clock speeds
         self.registerGPUMetric(self.__prefix + "sclk_clock_mhz", "gauge", "current sclk clock speed (Mhz)")
         self.registerGPUMetric(self.__prefix + "mclk_clock_mhz", "gauge", "current mclk clock speed (Mhz)")
@@ -565,9 +563,7 @@ class ROCMSMI(Collector):
                 ctypes.byref(energy_timestamp),
             )
             if ret == 0:
-                self.__GPUmetrics[metric].labels(card=gpuLabel).set(
-                    energy.value / 1000000.0
-                )
+                self.__GPUmetrics[metric].labels(card=gpuLabel).set(energy.value / 1000000.0)
             else:
                 self.__GPUmetrics[metric].labels(card=gpuLabel).set(0.0)
 

--- a/omnistat/collector_rocmsmi.py
+++ b/omnistat/collector_rocmsmi.py
@@ -563,7 +563,8 @@ class ROCMSMI(Collector):
                 ctypes.byref(energy_timestamp),
             )
             if ret == 0:
-                self.__GPUmetrics[metric].labels(card=gpuLabel).set(energy.value / 1000000.0)
+                energy_uJ = energy.value * energy_resolution.value
+                self.__GPUmetrics[metric].labels(card=gpuLabel).set(energy_uJ / 1000000.0)
             else:
                 self.__GPUmetrics[metric].labels(card=gpuLabel).set(0.0)
 

--- a/omnistat/collector_rocmsmi.py
+++ b/omnistat/collector_rocmsmi.py
@@ -375,6 +375,10 @@ class ROCMSMI(Collector):
         self.registerGPUMetric(
             self.__prefix + "average_socket_power_watts", "gauge", "Average Graphics Package Power (W)"
         )
+        # energy
+        self.registerGPUMetric(
+            self.__prefix + "energy_joules", "gauge", "Cumulative energy consumption (J)"
+        )
         # clock speeds
         self.registerGPUMetric(self.__prefix + "sclk_clock_mhz", "gauge", "current sclk clock speed (Mhz)")
         self.registerGPUMetric(self.__prefix + "mclk_clock_mhz", "gauge", "current mclk clock speed (Mhz)")
@@ -507,6 +511,9 @@ class ROCMSMI(Collector):
         pcie_received = ctypes.c_uint64(0)
         pcie_max_pkt_sz = ctypes.c_uint64(0)
         ras_counts = rsmi_error_count_t()
+        energy = ctypes.c_uint64(0)
+        energy_resolution = ctypes.c_float(0)
+        energy_timestamp = ctypes.c_uint64(0)
 
         for i in range(self.__num_gpus):
 
@@ -544,6 +551,22 @@ class ROCMSMI(Collector):
                 ret = self.__libsmi.rsmi_dev_power_get(device, ctypes.byref(power), ctypes.byref(power_type))
             if ret == 0:
                 self.__GPUmetrics[metric].labels(card=gpuLabel).set(power.value / 1000000.0)
+            else:
+                self.__GPUmetrics[metric].labels(card=gpuLabel).set(0.0)
+
+            # --
+            # cumulative energy [micro Joules, converted to Joules]
+            metric = self.__prefix + "energy_joules"
+            ret = self.__libsmi.rsmi_dev_energy_count_get(
+                device,
+                ctypes.byref(energy),
+                ctypes.byref(energy_resolution),
+                ctypes.byref(energy_timestamp),
+            )
+            if ret == 0:
+                self.__GPUmetrics[metric].labels(card=gpuLabel).set(
+                    energy.value / 1000000.0
+                )
             else:
                 self.__GPUmetrics[metric].labels(card=gpuLabel).set(0.0)
 

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -49,6 +49,7 @@ SMI_METRICS = [
     {"name":"rocm_temperature_celsius",                     "validate":">=10",               "labels":["card","location"]},
     {"name":"rocm_temperature_memory_celsius",              "validate":">=10",               "labels":["card","location"]},
     {"name":"rocm_average_socket_power_watts",              "validate":">=10",               "labels":["card"]},
+    {"name":"rocm_energy_joules",                           "validate":">10",                "labels":["card"]},
     {"name":"rocm_sclk_clock_mhz",                          "validate":">=90" ,              "labels":["card"]},
     {"name":"rocm_mclk_clock_mhz",                          "validate":">=100",              "labels":["card"]},
     {"name":"rocm_vram_total_bytes",                        "validate":">1073741824",        "labels":["card"]},

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -136,13 +136,15 @@ COLLECTOR_CONFIGS = [
     {
         "collectors": ["rocm_smi"],
         # rocm-smi interface is known to not report energy correctly on MI3XX
-        "metrics": SMI_METRICS + [
+        "metrics": SMI_METRICS
+        + [
             {"name": "rocm_energy_joules", "validate": ">=0" if "MI3" in gpu_type else ">10", "labels": ["card"]},
         ],
     },
     {
         "collectors": ["amd_smi"],
-        "metrics": SMI_METRICS + [
+        "metrics": SMI_METRICS
+        + [
             {"name": "rocm_energy_joules", "validate": ">10", "labels": ["card"]},
         ],
     },

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -49,7 +49,6 @@ SMI_METRICS = [
     {"name":"rocm_temperature_celsius",                     "validate":">=10",               "labels":["card","location"]},
     {"name":"rocm_temperature_memory_celsius",              "validate":">=10",               "labels":["card","location"]},
     {"name":"rocm_average_socket_power_watts",              "validate":">=10",               "labels":["card"]},
-    {"name":"rocm_energy_joules",                           "validate":">10",                "labels":["card"]},
     {"name":"rocm_sclk_clock_mhz",                          "validate":">=90" ,              "labels":["card"]},
     {"name":"rocm_mclk_clock_mhz",                          "validate":">=100",              "labels":["card"]},
     {"name":"rocm_vram_total_bytes",                        "validate":">1073741824",        "labels":["card"]},
@@ -136,11 +135,16 @@ print(f"test execution hostname: {full_hostname}\n")
 COLLECTOR_CONFIGS = [
     {
         "collectors": ["rocm_smi"],
-        "metrics": SMI_METRICS,
+        # rocm-smi interface is known to not report energy correctly on MI3XX
+        "metrics": SMI_METRICS + [
+            {"name": "rocm_energy_joules", "validate": ">=0" if "MI3" in gpu_type else ">10", "labels": ["card"]},
+        ],
     },
     {
         "collectors": ["amd_smi"],
-        "metrics": SMI_METRICS,
+        "metrics": SMI_METRICS + [
+            {"name": "rocm_energy_joules", "validate": ">10", "labels": ["card"]},
+        ],
     },
     {
         "collectors": ["rocm_smi", "ras_ecc"],


### PR DESCRIPTION
Introduces a new metric for both SMI variants: `rocm_energy_joules` that tracks cumulative energy usage on a per gpu basis.  Data is accumulated since last GPU driver load.

---

Example Prometheus/Grafana query using this new metric to sum energy on a per-gpu basis is as follows:

`sum by (card) (running_sum(increase( rocm_energy_joules * on(instance) group_left() rmsjob_info{jobid="$jobid"})))`

<img width="647" height="269" alt="image" src="https://github.com/user-attachments/assets/473e272d-cf1e-47b1-a3c0-1c2f00e14a11" />
