### PR TITLE
Support for AMD AI NICs in the network collector

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -301,8 +301,8 @@ export ROCP_TOOL_LIBRARIES=/path/to/build-trace/libomnistat_trace.so
 
 The network data collector enables metrics providing information about data
 transfers for each network interface detected in the host platform. Currently
-supported network types include Ethernet, Infiniband, and
-Slingshot.
+supported network types include Ethernet, Infiniband, Slingshot, and AINIC (AMD
+Pensando `ionic` NICs such as Pollara).
 
 **Collector**: `enable_network`
 

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -16,11 +16,10 @@ distributed with Omnistat, along with their supported metrics:
 | `source`            | :heavy_check_mark:[^1] | :heavy_check_mark: |
 | `system/rms`        | :heavy_check_mark:     | :heavy_check_mark: |
 | `system/standalone` | :heavy_check_mark:     |                    |
-| `docker`[^3]        | :heavy_check_mark:     | :heavy_check_mark: |
+| `docker`[^2]        | :heavy_check_mark:     | :heavy_check_mark: |
 
 [^1]: Includes throttling events (experimental).
-[^2]: Includes CPU, memory, IO, ethernet, and IB panels.
-[^3]: Docker dashboards are meant to be used in local Docker-based Grafana
+[^2]: Docker dashboards are meant to be used in local Docker-based Grafana
       instances to access local data collected in usermode.
 
 ## Generate Custom Dashboards

--- a/omnistat/collector_network.py
+++ b/omnistat/collector_network.py
@@ -25,7 +25,7 @@
 """Network monitoring
 
 Implements a prometheus info metric to track network traffic data for interfaces
-exposed under /sys/class/net and /sys/class/cxi.
+exposed under /sys/class/{net,cxi,infiniband}.
 """
 
 import configparser
@@ -65,6 +65,40 @@ class NETWORK(Collector):
         # Files to check for for infiniband devices.
         self.__ib_rx_data_paths = {}
         self.__ib_tx_data_paths = {}
+
+        # Files to check for AMD AI NIC (AINIC) devices, i.e. AMD Pensando
+        # "ionic" NICs such as Pollara. These appear under
+        # /sys/class/infiniband but do not expose the standard IB port
+        # counters; byte totals live in hw_counters instead. Unicast +
+        # multicast bytes feed the shared rx/tx metrics and capture both
+        # point-to-point RDMA and GPU-collective (RCCL) throughput.
+        self.__ainic_rx_data_paths = {}
+        self.__ainic_tx_data_paths = {}
+
+    def __is_ainic(self, nic):
+        """Return True if an infiniband-class device is an AMD AI NIC (AINIC).
+
+        AINICs (AMD Pensando "ionic" NICs, e.g. Pollara) use the "ionic"
+        driver; detect them via the device's uevent (robust). Fall back to the
+        sysfs signature of empty standard IB counters alongside populated
+        hw_counters if the uevent is unreadable.
+        """
+        try:
+            uevent = (nic / "device" / "uevent").read_text()
+            for line in uevent.splitlines():
+                if line == "DRIVER=ionic":
+                    return True
+            return False
+        except OSError:
+            pass
+
+        # Fallback: no standard IB byte counters, but hw_counters present.
+        for port in (nic / "ports").iterdir():
+            counters = port / "counters" / "port_rcv_data"
+            hw_counters = port / "hw_counters" / "rx_rdma_ucast_bytes"
+            if not counters.is_file() and hw_counters.is_file():
+                return True
+        return False
 
     def registerMetrics(self):
         """Register metrics of interest"""
@@ -141,6 +175,18 @@ class NETWORK(Collector):
         #       "mlx5_1:1": "/sys/class/infiniband/mlx5_1/ports/1/counters/port_rcv_data",
         #       }
         #   }
+        #
+        # AMD AI NICs ("ionic" driver, e.g. Pollara) also appear under as
+        # Infiniband but expose bytes via hw_counters instead of the standard
+        # IB counters, so they are detected and handled separately in the
+        # loop below. Their unicast/multicast byte paths are indexed by
+        # interface and port ID. For example, for Rx bandwidth:
+        #   __ainic_rx_data_paths = {
+        #       "ionic_0:1": [
+        #           "/sys/class/infiniband/ionic_0/ports/1/hw_counters/rx_rdma_ucast_bytes",
+        #           "/sys/class/infiniband/ionic_0/ports/1/hw_counters/rx_rdma_mcast_bytes",
+        #       ]
+        #   }
         ib_base_path = Path("/sys/class/infiniband")
 
         ib_nics = []
@@ -152,16 +198,32 @@ class NETWORK(Collector):
                 continue
 
             ports = nic / "ports"
-            for port in ports.iterdir():
-                nic_name = f"{nic.name}:{port.name}"
 
-                rx_path = port / "counters" / "port_rcv_data"
-                if rx_path.is_file() and rx_path.stat().st_size > 0:
-                    self.__ib_rx_data_paths[nic_name] = rx_path
+            if self.__is_ainic(nic):
+                for port in ports.iterdir():
+                    nic_name = f"{nic.name}:{port.name}"
+                    hw = port / "hw_counters"
 
-                tx_path = port / "counters" / "port_xmit_data"
-                if tx_path.is_file() and tx_path.stat().st_size > 0:
-                    self.__ib_tx_data_paths[nic_name] = tx_path
+                    rx_ucast = hw / "rx_rdma_ucast_bytes"
+                    rx_mcast = hw / "rx_rdma_mcast_bytes"
+                    if rx_ucast.is_file() and rx_ucast.stat().st_size > 0:
+                        self.__ainic_rx_data_paths[nic_name] = [rx_ucast, rx_mcast]
+
+                    tx_ucast = hw / "tx_rdma_ucast_bytes"
+                    tx_mcast = hw / "tx_rdma_mcast_bytes"
+                    if tx_ucast.is_file() and tx_ucast.stat().st_size > 0:
+                        self.__ainic_tx_data_paths[nic_name] = [tx_ucast, tx_mcast]
+            else:
+                for port in ports.iterdir():
+                    nic_name = f"{nic.name}:{port.name}"
+
+                    rx_path = port / "counters" / "port_rcv_data"
+                    if rx_path.is_file() and rx_path.stat().st_size > 0:
+                        self.__ib_rx_data_paths[nic_name] = rx_path
+
+                    tx_path = port / "counters" / "port_xmit_data"
+                    if tx_path.is_file() and tx_path.stat().st_size > 0:
+                        self.__ib_tx_data_paths[nic_name] = tx_path
 
         # Register Prometheus metrics for Rx and Tx. Devices are identified by
         # device class and interface name. For example, the Prometheus metric
@@ -169,7 +231,12 @@ class NETWORK(Collector):
         #   network_rx_bytes{device_class="net",interface="eth0"}
         labels = ["device_class", "interface"]
 
-        rx_data_paths = [self.__net_rx_data_paths, self.__cxi_rx_data_paths, self.__ib_rx_data_paths]
+        rx_data_paths = [
+            self.__net_rx_data_paths,
+            self.__cxi_rx_data_paths,
+            self.__ib_rx_data_paths,
+            self.__ainic_rx_data_paths,
+        ]
         num_rx = sum([len(x) for x in rx_data_paths])
         if num_rx > 0:
             logging.debug(self.__net_rx_data_paths)
@@ -178,7 +245,12 @@ class NETWORK(Collector):
             self.__rx_metric = Gauge(metric, description, labelnames=labels)
             logging.info(f"--> [registered] {metric} -> {description} (gauge)")
 
-        tx_data_paths = [self.__net_tx_data_paths, self.__cxi_tx_data_paths, self.__ib_tx_data_paths]
+        tx_data_paths = [
+            self.__net_tx_data_paths,
+            self.__cxi_tx_data_paths,
+            self.__ib_tx_data_paths,
+            self.__ainic_tx_data_paths,
+        ]
         num_tx = sum([len(x) for x in tx_data_paths])
         if num_tx > 0:
             logging.debug(self.__net_tx_data_paths)
@@ -241,5 +313,23 @@ class NETWORK(Collector):
                         metric.labels(device_class="infiniband", interface=nic).set(data * 4)
                 except:
                     pass
+
+        # AINIC: hw_counters are already in bytes (no scaling, no timestamp).
+        # rx/tx aggregate unicast + multicast.
+        ainic_data = [
+            (self.__ainic_rx_data_paths, self.__rx_metric),
+            (self.__ainic_tx_data_paths, self.__tx_metric),
+        ]
+
+        for data_paths, metric in ainic_data:
+            for nic, paths in data_paths.items():
+                total = 0
+                for path in paths:
+                    try:
+                        with open(path, "r") as f:
+                            total += int(f.read().strip())
+                    except:
+                        pass
+                metric.labels(device_class="ainic", interface=nic).set(total)
 
         return

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -104,6 +104,14 @@ ROCPROFILER_METRICS = [
     {"name": "omnistat_hardware_counter",                    "validate": ">=0",               "labels": ["source", "card", "name"]},
 ]
 
+# Network metrics are hardware-dependent (specific device classes such as
+# "cxi" or "ainic" only appear on matching NICs), so assertions stay generic:
+# any host with a non-loopback interface exposes rx/tx byte totals.
+NETWORK_METRICS = [
+    {"name": "omnistat_network_rx_bytes",                    "validate": ">=0",               "labels": ["device_class", "interface"]},
+    {"name": "omnistat_network_tx_bytes",                    "validate": ">=0",               "labels": ["device_class", "interface"]},
+]
+
 # fmt: on
 
 
@@ -171,6 +179,10 @@ COLLECTOR_CONFIGS = [
     {
         "collectors": ["host_metrics", "omnistat.collectors.host::enable_proc_io_stats"],
         "metrics": HOST_METRICS,
+    },
+    {
+        "collectors": ["network"],
+        "metrics": NETWORK_METRICS,
     },
     {
         "collectors": ["rocprofiler"],


### PR DESCRIPTION
Adds support for AMD AI NICs (AMD Pensando "ionic" NICs such as Pollara 400) to the Omnistat network collector. These NICs enumerate under `/sys/class/infiniband` and so previously looked like Infiniband to Omnistat, but they do **not** populate the standard IB port counters (`ports/*/counters/port_rcv_data|port_xmit_data` is empty), so no traffic was being reported for them. AINIC byte totals instead live under `ports/*/hw_counters/` as plain byte values.

AINIC rx/tx bytes are now reported via the existing `omnistat_network_{rx,tx}_bytes` gauges with a new `device_class="ainic"`, aggregating unicast + multicast RDMA bytes. This captures both point-to-point RDMA and GPU-collective (RCCL) throughput.

### What changed

- [x] Detect AINICs during `/sys/class/infiniband` discovery via `DRIVER=ionic` in the device `uevent` (with a sysfs-signature fallback), and route them away from the standard IB counter path.
- [x] Read `rx_rdma_ucast_bytes` + `rx_rdma_mcast_bytes` (and tx equivalents) from `hw_counters`; values are already in bytes.
- [x] Emit `omnistat_network_{rx,tx}_bytes{device_class="ainic"}`; no new config flag required (`enable_network` already governs it).
- [x] Update `docs/metrics.md` to list AINIC as a supported network type.
- [x] Add network-collector test to `test/test_collectors.py` (`omnistat_network_{rx,tx}_bytes`, generic hardware-agnostic assertions).

### Notes / decisions

- **No Grafana dashboard changes.** The dashboards already split Ethernet (`device_class="net"`) from "High Performance Interconnect" (`device_class!="net"`), so AINIC traffic is captured automatically.
- **`ccl_cts` counters were intentionally excluded.** A controlled 2-node RCCL run showed collective traffic is counted in `ucast_bytes`, while `ccl_cts` is a low-volume, fixed-24-byte, tx==rx-symmetric control/credit channel (unchanged by both point-to-point RDMA and RCCL collectives), not throughput worth surfacing.
- Naming follows AMD's own "AINIC" category rather than the product name "Pollara", to stay forward-compatible with future `ionic` AI NICs.

### Verification performed

All exercised on real hardware (AMD Instinct MI355X nodes with 8x Pollara NICs, `ionic` driver, RoCEv2 @ 400 Gb/s):

- [x] **Counter semantics confirmed with a controlled `ib_write_bw` loopback**: transferring exactly 5,242,880,000 bytes moved `{tx,rx}_rdma_ucast_bytes` by exactly that amount (confirming bytes, no scaling factor).
- [x] **RCCL attribution confirmed via a controlled 2-node all-reduce** (353 GB/s over the fabric): `ucast_bytes` grew by +26.06 GB on every NIC per node; `ccl_cts` stayed at 0, validating that `rx/tx_bytes` captures collective throughput and justifying the `ccl_cts` exclusion.
- [x] **Collector runs end-to-end on hardware**: instantiated `NETWORK`, scraped metrics, saw 16 `device_class="ainic"` samples emitted.

### Future work: congestion / retransmit metrics

Beyond raw throughput, the same `hw_counters` directory exposes fabric-health signals that are worth surfacing as follow-up work. All are readable from sysfs with no extra tooling, so they fit the existing pure-file-read collector pattern.

- **Retransmits**: `tx_rdma_retx_bytes`, `tx_rdma_retx_pkts`. Best single packet-loss / fabric-trouble signal. Observed on a busy production NIC: ~81 GB retransmitted out of ~5.1 TB sent (~1.6% of tx), 19.78M retransmitted packets.
- **Congestion (RoCEv2)**:`tx_rdma_cnp_pkts` (congestion notifications sent), `rx_rdma_cnp_pkts` (received), `rx_rdma_ecn_pkts` (ECN-marked packets received).
- (Optional) **ACK timeouts**: `tx_rdma_ack_timeout` (~11K observed), a secondary reliability indicator.
- (Optional) **Packet counts**:`{rx,tx}_rdma_ucast_pkts`, cheap to add alongside the byte counters we already read; enables packet-rate and average-packet-size.

### Future work: virtualized / logical network view

All testing so far has been on **bare metal**, where each AINIC maps to a single physical function under `/sys/class/infiniband`. The virtualized topology has not been validated:

- **VM / SR-IOV behavior**: AINICs expose Physical Functions (PFs) on the host/hypervisor and Virtual Functions (VFs) passed through to guest VMs. Inside a VM only the VF interfaces are visible, and the set of available counters likely differs.
- **Logical-interface (LIF) accounting**: a single physical NIC can present multiple logical interfaces; how these appear (and whether per-LIF traffic should be aggregated or reported separately) under `/sys/class/infiniband` in a virtualized setup is unverified. Our current `<nic>:<port>` keying assumes the bare-metal 1:1 mapping.
- Confirm the `DRIVER=ionic` detection and `hw_counters` presence/values behave correctly for a VF inside a guest VM (the sysfs layout and counter availability may differ from the PF view we tested).