### PR TITLE
Support AINIC and Thor network metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -312,21 +312,18 @@ Pensando `ionic` NICs such as Pollara), and Thor (Broadcom `bnxt_re` RoCE NICs).
 | `omnistat_network_tx_bytes` | Total bytes transmitted by network interface. Labels: `device_class`, `interface`. |
 | `omnistat_network_rx_bytes` | Total bytes received by network interface. Labels: `device_class`, `interface`. |
 
-### RoCE hw_counter metrics
-
-RoCE-over-Ethernet NICs that report via sysfs `hw_counters` (AINIC,
-`device_class="ainic"`; Thor, `device_class="thor"`) expose additional
+RoCE NICs that report via sysfs `hw_counters` (AINIC, Thor) expose additional
 throughput and fabric-health metrics. Availability depends on the counters the
-driver publishes, so a metric only appears for interfaces that provide it (all
-are currently reported for AINIC). For these NICs, `rx_bytes`/`tx_bytes` and
-`rx_packets`/`tx_packets` aggregate unicast and multicast RDMA traffic.
+driver publishes.
 
-| Node Metric                 | Description                          |
-| :-------------------------- | :----------------------------------- |
-| `omnistat_network_tx_packets` | Total packets transmitted by network interface. Labels: `device_class`, `interface`. |
-| `omnistat_network_rx_packets` | Total packets received by network interface. Labels: `device_class`, `interface`. |
-| `omnistat_network_retx_packets` | Total packets retransmitted by network interface; a fabric packet-loss/congestion indicator. Labels: `device_class`, `interface`. |
-| `omnistat_network_out_of_sequence_packets` | Total packets received out of sequence by network interface; typically driven by in-fabric packet loss. Labels: `device_class`, `interface`. |
+| Node Metric                 | Network Type   | Description                          |
+| :-------------------------- | :----------- | :----------------------------------- |
+| `omnistat_network_tx_packets` | AINIC, Thor | Total packets transmitted by network interface. |
+| `omnistat_network_rx_packets` | AINIC, Thor | Total packets received by network interface. |
+| `omnistat_network_out_of_sequence_packets` | AINIC, Thor | Total packets received out of sequence by network interface; typically driven by in-fabric packet loss. |
+| `omnistat_network_retx_packets` | AINIC | Total packets retransmitted by network interface; a fabric packet-loss/congestion indicator. |
+| `omnistat_network_rx_discarded_packets` | Thor | Total RoCE packets dropped on receive by network interface; a packet-loss indicator. |
+| `omnistat_network_tx_discarded_packets` | Thor | Total RoCE packets dropped on transmit by network interface; a packet-loss indicator. |
 
 <hr style="border: 1px solid black;">
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -312,6 +312,22 @@ Pensando `ionic` NICs such as Pollara), and Thor (Broadcom `bnxt_re` RoCE NICs).
 | `omnistat_network_tx_bytes` | Total bytes transmitted by network interface. Labels: `device_class`, `interface`. |
 | `omnistat_network_rx_bytes` | Total bytes received by network interface. Labels: `device_class`, `interface`. |
 
+### RoCE hw_counter metrics
+
+RoCE-over-Ethernet NICs that report via sysfs `hw_counters` (AINIC,
+`device_class="ainic"`; Thor, `device_class="thor"`) expose additional
+throughput and fabric-health metrics. Availability depends on the counters the
+driver publishes, so a metric only appears for interfaces that provide it (all
+are currently reported for AINIC). For these NICs, `rx_bytes`/`tx_bytes` and
+`rx_packets`/`tx_packets` aggregate unicast and multicast RDMA traffic.
+
+| Node Metric                 | Description                          |
+| :-------------------------- | :----------------------------------- |
+| `omnistat_network_tx_packets` | Total packets transmitted by network interface. Labels: `device_class`, `interface`. |
+| `omnistat_network_rx_packets` | Total packets received by network interface. Labels: `device_class`, `interface`. |
+| `omnistat_network_retx_packets` | Total packets retransmitted by network interface; a fabric packet-loss/congestion indicator. Labels: `device_class`, `interface`. |
+| `omnistat_network_out_of_sequence_packets` | Total packets received out of sequence by network interface; typically driven by in-fabric packet loss. Labels: `device_class`, `interface`. |
+
 <hr style="border: 1px solid black;">
 
 ## External

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -301,9 +301,14 @@ export ROCP_TOOL_LIBRARIES=/path/to/build-trace/libomnistat_trace.so
 ## Network
 
 The network data collector enables metrics providing information about data
-transfers for each network interface detected in the host platform. Currently
-supported network types include Ethernet, Infiniband, Slingshot, AINIC (AMD
-Pensando `ionic` NICs such as Pollara), and Thor (Broadcom `bnxt_re` RoCE NICs).
+transfers for each network interface detected in the host platform. Every
+interface carries a `device_class` label naming the type it was detected as:
+
+- `net`: Ethernet and other standard IP interfaces.
+- `infiniband`: Infiniband.
+- `cxi`: Slingshot.
+- `ionic`: AINIC (AMD Pensando, e.g. Pollara).
+- `bnxt_re`: Thor (Broadcom RoCE).
 
 **Collector**: `enable_network`
 
@@ -321,16 +326,16 @@ receiver counts ECN-marked packets and answers with a CNP, which the sender
 counts as a request to lower its send rate. Both count packets *received*, but
 they report congestion in opposite traffic directions.
 
-| Node Metric                 | Network Type   | Description                          |
+| Node Metric                 | Network Type | Description                          |
 | :-------------------------- | :----------- | :----------------------------------- |
-| `omnistat_network_tx_packets` | AINIC, Thor | Total packets transmitted by network interface. |
-| `omnistat_network_rx_packets` | AINIC, Thor | Total packets received by network interface. |
-| `omnistat_network_out_of_sequence_packets` | AINIC, Thor | Total packets received out of sequence by network interface; typically driven by in-fabric packet loss. |
-| `omnistat_network_retx_packets` | AINIC | Total packets retransmitted by network interface; a fabric packet-loss/congestion indicator. |
-| `omnistat_network_rx_discarded_packets` | Thor | Total packets dropped on receive by network interface; a packet-loss indicator. |
-| `omnistat_network_tx_discarded_packets` | Thor | Total packets dropped on transmit by network interface; a packet-loss indicator. |
-| `omnistat_network_rx_ecn_marked_packets` | AINIC, Thor | Total packets received carrying the ECN congestion mark; a pre-loss indicator of congestion on **inbound** traffic. |
-| `omnistat_network_rx_cnp_packets` | AINIC, Thor | Total congestion notification packets (CNPs) received, each requesting a lower send rate; an indicator of congestion on **outbound** traffic. |
+| `omnistat_network_tx_packets` | `ionic`, `bnxt_re` | Total packets transmitted by network interface. |
+| `omnistat_network_rx_packets` | `ionic`, `bnxt_re` | Total packets received by network interface. |
+| `omnistat_network_out_of_sequence_packets` | `ionic`, `bnxt_re` | Total packets received out of sequence by network interface; typically driven by in-fabric packet loss. |
+| `omnistat_network_retx_packets` | `ionic` | Total packets retransmitted by network interface; a fabric packet-loss/congestion indicator. |
+| `omnistat_network_rx_discarded_packets` | `bnxt_re` | Total packets dropped on receive by network interface; a packet-loss indicator. |
+| `omnistat_network_tx_discarded_packets` | `bnxt_re` | Total packets dropped on transmit by network interface; a packet-loss indicator. |
+| `omnistat_network_rx_ecn_marked_packets` | `ionic`, `bnxt_re` | Total packets received carrying the ECN congestion mark; a pre-loss indicator of congestion on **inbound** traffic. |
+| `omnistat_network_rx_cnp_packets` | `ionic`, `bnxt_re` | Total congestion notification packets (CNPs) received, each requesting a lower send rate; an indicator of congestion on **outbound** traffic. |
 
 <hr style="border: 1px solid black;">
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -89,7 +89,7 @@ memory utilization statistics along with general I/O metrics.
 | `omnistat_io_read_local_total_bytes` | Total block-level data read from **local** physical disks (bytes).|
 | `omnistat_io_write_local_total_bytes` | Total bock-level data written to **local** physical disk (bytes). |
 
-### Process-based I/O 
+### Process-based I/O
 
 **Collector**: `enable_host_metrics`
 <br/>
@@ -322,8 +322,11 @@ driver publishes.
 | `omnistat_network_rx_packets` | AINIC, Thor | Total packets received by network interface. |
 | `omnistat_network_out_of_sequence_packets` | AINIC, Thor | Total packets received out of sequence by network interface; typically driven by in-fabric packet loss. |
 | `omnistat_network_retx_packets` | AINIC | Total packets retransmitted by network interface; a fabric packet-loss/congestion indicator. |
-| `omnistat_network_rx_discarded_packets` | Thor | Total RoCE packets dropped on receive by network interface; a packet-loss indicator. |
-| `omnistat_network_tx_discarded_packets` | Thor | Total RoCE packets dropped on transmit by network interface; a packet-loss indicator. |
+| `omnistat_network_rx_discarded_packets` | Thor | Total packets dropped on receive by network interface; a packet-loss indicator. |
+| `omnistat_network_tx_discarded_packets` | Thor | Total packets dropped on transmit by network interface; a packet-loss indicator. |
+| `omnistat_network_ecn_marked_packets` | Thor | Total packets received with the ECN congestion mark; a pre-loss congestion indicator. |
+| `omnistat_network_cnp_sent_packets` | Thor | Total DCQCN congestion notification packets (CNPs) sent by network interface in response to ECN-marked traffic. |
+| `omnistat_network_cnp_handled_packets` | Thor | Total DCQCN congestion notification packets (CNPs) received and acted on by network interface (send rate throttled). |
 
 <hr style="border: 1px solid black;">
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -330,8 +330,8 @@ they report congestion in opposite traffic directions.
 | :-------------------------- | :----------- | :----------------------------------- |
 | `omnistat_network_tx_packets` | `ionic`, `bnxt_re` | Total packets transmitted by network interface. |
 | `omnistat_network_rx_packets` | `ionic`, `bnxt_re` | Total packets received by network interface. |
-| `omnistat_network_out_of_sequence_packets` | `ionic`, `bnxt_re` | Total packets received out of sequence by network interface; typically driven by in-fabric packet loss. |
-| `omnistat_network_retx_packets` | `ionic` | Total packets retransmitted by network interface; a fabric packet-loss/congestion indicator. |
+| `omnistat_network_rx_out_of_sequence_packets` | `ionic`, `bnxt_re` | Total packets received out of sequence by network interface; typically driven by in-fabric packet loss. |
+| `omnistat_network_tx_retransmitted_packets` | `ionic` | Total packets retransmitted by network interface; a fabric packet-loss/congestion indicator. |
 | `omnistat_network_rx_discarded_packets` | `bnxt_re` | Total packets dropped on receive by network interface; a packet-loss indicator. |
 | `omnistat_network_tx_discarded_packets` | `bnxt_re` | Total packets dropped on transmit by network interface; a packet-loss indicator. |
 | `omnistat_network_rx_ecn_marked_packets` | `ionic`, `bnxt_re` | Total packets received carrying the ECN congestion mark; a pre-loss indicator of congestion on **inbound** traffic. |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -302,8 +302,8 @@ export ROCP_TOOL_LIBRARIES=/path/to/build-trace/libomnistat_trace.so
 
 The network data collector enables metrics providing information about data
 transfers for each network interface detected in the host platform. Currently
-supported network types include Ethernet, Infiniband, and
-Slingshot.
+supported network types include Ethernet, Infiniband, Slingshot, and AINIC (AMD
+Pensando `ionic` NICs such as Pollara).
 
 **Collector**: `enable_network`
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -302,8 +302,8 @@ export ROCP_TOOL_LIBRARIES=/path/to/build-trace/libomnistat_trace.so
 
 The network data collector enables metrics providing information about data
 transfers for each network interface detected in the host platform. Currently
-supported network types include Ethernet, Infiniband, Slingshot, and AINIC (AMD
-Pensando `ionic` NICs such as Pollara).
+supported network types include Ethernet, Infiniband, Slingshot, AINIC (AMD
+Pensando `ionic` NICs such as Pollara), and Thor (Broadcom `bnxt_re` RoCE NICs).
 
 **Collector**: `enable_network`
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -324,9 +324,8 @@ driver publishes.
 | `omnistat_network_retx_packets` | AINIC | Total packets retransmitted by network interface; a fabric packet-loss/congestion indicator. |
 | `omnistat_network_rx_discarded_packets` | Thor | Total packets dropped on receive by network interface; a packet-loss indicator. |
 | `omnistat_network_tx_discarded_packets` | Thor | Total packets dropped on transmit by network interface; a packet-loss indicator. |
-| `omnistat_network_ecn_marked_packets` | Thor | Total packets received with the ECN congestion mark; a pre-loss congestion indicator. |
-| `omnistat_network_cnp_sent_packets` | Thor | Total DCQCN congestion notification packets (CNPs) sent by network interface in response to ECN-marked traffic. |
-| `omnistat_network_cnp_handled_packets` | Thor | Total DCQCN congestion notification packets (CNPs) received and acted on by network interface (send rate throttled). |
+| `omnistat_network_ecn_marked_packets` | AINIC, Thor | Total packets received with the ECN congestion mark; a pre-loss congestion indicator. |
+| `omnistat_network_rx_cnp_packets` | AINIC | Total DCQCN congestion notification packets (CNPs) received by network interface, indicating its send rate is being throttled by peers. |
 
 <hr style="border: 1px solid black;">
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -316,6 +316,11 @@ RoCE NICs that report via sysfs `hw_counters` (AINIC, Thor) expose additional
 throughput and fabric-health metrics. Availability depends on the counters the
 driver publishes.
 
+The ECN and CNP metrics are the two ends of the same DCQCN feedback loop: a
+receiver counts ECN-marked packets and answers with a CNP, which the sender
+counts as a request to lower its send rate. Both count packets *received*, but
+they report congestion in opposite traffic directions.
+
 | Node Metric                 | Network Type   | Description                          |
 | :-------------------------- | :----------- | :----------------------------------- |
 | `omnistat_network_tx_packets` | AINIC, Thor | Total packets transmitted by network interface. |
@@ -324,8 +329,8 @@ driver publishes.
 | `omnistat_network_retx_packets` | AINIC | Total packets retransmitted by network interface; a fabric packet-loss/congestion indicator. |
 | `omnistat_network_rx_discarded_packets` | Thor | Total packets dropped on receive by network interface; a packet-loss indicator. |
 | `omnistat_network_tx_discarded_packets` | Thor | Total packets dropped on transmit by network interface; a packet-loss indicator. |
-| `omnistat_network_ecn_marked_packets` | AINIC, Thor | Total packets received with the ECN congestion mark; a pre-loss congestion indicator. |
-| `omnistat_network_rx_cnp_packets` | AINIC | Total DCQCN congestion notification packets (CNPs) received by network interface, indicating its send rate is being throttled by peers. |
+| `omnistat_network_rx_ecn_marked_packets` | AINIC, Thor | Total packets received carrying the ECN congestion mark; a pre-loss indicator of congestion on **inbound** traffic. |
+| `omnistat_network_rx_cnp_packets` | AINIC, Thor | Total congestion notification packets (CNPs) received, each requesting a lower send rate; an indicator of congestion on **outbound** traffic. |
 
 <hr style="border: 1px solid black;">
 

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -16,11 +16,10 @@ distributed with Omnistat, along with their supported metrics:
 | `source`            | :heavy_check_mark:[^1] | :heavy_check_mark: |
 | `system/rms`        | :heavy_check_mark:     | :heavy_check_mark: |
 | `system/standalone` | :heavy_check_mark:     |                    |
-| `docker`[^3]        | :heavy_check_mark:     | :heavy_check_mark: |
+| `docker`[^2]        | :heavy_check_mark:     | :heavy_check_mark: |
 
 [^1]: Includes throttling events (experimental).
-[^2]: Includes CPU, memory, IO, ethernet, and IB panels.
-[^3]: Docker dashboards are meant to be used in local Docker-based Grafana
+[^2]: Docker dashboards are meant to be used in local Docker-based Grafana
       instances to access local data collected in usermode.
 
 ## Generate Custom Dashboards

--- a/omnistat/collector_network.py
+++ b/omnistat/collector_network.py
@@ -91,7 +91,7 @@ class NETWORK(Collector):
                 "tx_packets": ["tx_rdma_ucast_pkts", "tx_rdma_mcast_pkts"],
                 "retx_packets": ["tx_rdma_retx_pkts"],
                 "out_of_sequence_packets": ["req_rx_pkt_seq_err"],
-                "ecn_marked_packets": ["rx_rdma_ecn_pkts"],
+                "rx_ecn_marked_packets": ["rx_rdma_ecn_pkts"],
                 "rx_cnp_packets": ["rx_rdma_cnp_pkts"],
             },
         },
@@ -108,7 +108,8 @@ class NETWORK(Collector):
                 "out_of_sequence_packets": ["out_of_sequence"],
                 "rx_discarded_packets": ["rx_roce_discards"],
                 "tx_discarded_packets": ["tx_roce_discards"],
-                "ecn_marked_packets": ["np_ecn_marked_roce_packets"],
+                "rx_ecn_marked_packets": ["np_ecn_marked_roce_packets"],
+                "rx_cnp_packets": ["rp_cnp_handled", "rp_cnp_ignored"],
             },
         },
     }

--- a/omnistat/collector_network.py
+++ b/omnistat/collector_network.py
@@ -25,7 +25,7 @@
 """Network monitoring
 
 Implements a prometheus info metric to track network traffic data for interfaces
-exposed under /sys/class/net and /sys/class/cxi.
+exposed under /sys/class/{net,cxi,infiniband}.
 """
 
 import configparser
@@ -65,6 +65,40 @@ class NETWORK(Collector):
         # Files to check for for infiniband devices.
         self.__ib_rx_data_paths = {}
         self.__ib_tx_data_paths = {}
+
+        # Files to check for AMD AI NIC (AINIC) devices, i.e. AMD Pensando
+        # "ionic" NICs such as Pollara. These appear under
+        # /sys/class/infiniband but do not expose the standard IB port
+        # counters; byte totals live in hw_counters instead. Unicast +
+        # multicast bytes feed the shared rx/tx metrics and capture both
+        # point-to-point RDMA and GPU-collective (RCCL) throughput.
+        self.__ainic_rx_data_paths = {}
+        self.__ainic_tx_data_paths = {}
+
+    def __is_ainic(self, nic):
+        """Return True if an infiniband-class device is an AMD AI NIC (AINIC).
+
+        AINICs (AMD Pensando "ionic" NICs, e.g. Pollara) use the "ionic"
+        driver; detect them via the device's uevent (robust). Fall back to the
+        sysfs signature of empty standard IB counters alongside populated
+        hw_counters if the uevent is unreadable.
+        """
+        try:
+            uevent = (nic / "device" / "uevent").read_text()
+            for line in uevent.splitlines():
+                if line == "DRIVER=ionic":
+                    return True
+            return False
+        except OSError:
+            pass
+
+        # Fallback: no standard IB byte counters, but hw_counters present.
+        for port in (nic / "ports").iterdir():
+            counters = port / "counters" / "port_rcv_data"
+            hw_counters = port / "hw_counters" / "rx_rdma_ucast_bytes"
+            if not counters.is_file() and hw_counters.is_file():
+                return True
+        return False
 
     def registerMetrics(self):
         """Register metrics of interest"""
@@ -141,6 +175,18 @@ class NETWORK(Collector):
         #       "mlx5_1:1": "/sys/class/infiniband/mlx5_1/ports/1/counters/port_rcv_data",
         #       }
         #   }
+        #
+        # AMD AI NICs ("ionic" driver, e.g. Pollara) also appear under as
+        # Infiniband but expose bytes via hw_counters instead of the standard
+        # IB counters, so they are detected and handled separately in the
+        # loop below. Their unicast/multicast byte paths are indexed by
+        # interface and port ID. For example, for Rx bandwidth:
+        #   __ainic_rx_data_paths = {
+        #       "ionic_0:1": [
+        #           "/sys/class/infiniband/ionic_0/ports/1/hw_counters/rx_rdma_ucast_bytes",
+        #           "/sys/class/infiniband/ionic_0/ports/1/hw_counters/rx_rdma_mcast_bytes",
+        #       ]
+        #   }
         ib_base_path = Path("/sys/class/infiniband")
 
         ib_nics = []
@@ -152,16 +198,32 @@ class NETWORK(Collector):
                 continue
 
             ports = nic / "ports"
-            for port in ports.iterdir():
-                nic_name = f"{nic.name}:{port.name}"
 
-                rx_path = port / "counters" / "port_rcv_data"
-                if rx_path.is_file() and rx_path.stat().st_size > 0:
-                    self.__ib_rx_data_paths[nic_name] = rx_path
+            if self.__is_ainic(nic):
+                for port in ports.iterdir():
+                    nic_name = f"{nic.name}:{port.name}"
+                    hw = port / "hw_counters"
 
-                tx_path = port / "counters" / "port_xmit_data"
-                if tx_path.is_file() and tx_path.stat().st_size > 0:
-                    self.__ib_tx_data_paths[nic_name] = tx_path
+                    rx_ucast = hw / "rx_rdma_ucast_bytes"
+                    rx_mcast = hw / "rx_rdma_mcast_bytes"
+                    if rx_ucast.is_file() and rx_ucast.stat().st_size > 0:
+                        self.__ainic_rx_data_paths[nic_name] = [rx_ucast, rx_mcast]
+
+                    tx_ucast = hw / "tx_rdma_ucast_bytes"
+                    tx_mcast = hw / "tx_rdma_mcast_bytes"
+                    if tx_ucast.is_file() and tx_ucast.stat().st_size > 0:
+                        self.__ainic_tx_data_paths[nic_name] = [tx_ucast, tx_mcast]
+            else:
+                for port in ports.iterdir():
+                    nic_name = f"{nic.name}:{port.name}"
+
+                    rx_path = port / "counters" / "port_rcv_data"
+                    if rx_path.is_file() and rx_path.stat().st_size > 0:
+                        self.__ib_rx_data_paths[nic_name] = rx_path
+
+                    tx_path = port / "counters" / "port_xmit_data"
+                    if tx_path.is_file() and tx_path.stat().st_size > 0:
+                        self.__ib_tx_data_paths[nic_name] = tx_path
 
         # Register Prometheus metrics for Rx and Tx. Devices are identified by
         # device class and interface name. For example, the Prometheus metric
@@ -169,7 +231,12 @@ class NETWORK(Collector):
         #   network_rx_bytes{device_class="net",interface="eth0"}
         labels = ["device_class", "interface"]
 
-        rx_data_paths = [self.__net_rx_data_paths, self.__cxi_rx_data_paths, self.__ib_rx_data_paths]
+        rx_data_paths = [
+            self.__net_rx_data_paths,
+            self.__cxi_rx_data_paths,
+            self.__ib_rx_data_paths,
+            self.__ainic_rx_data_paths,
+        ]
         num_rx = sum([len(x) for x in rx_data_paths])
         if num_rx > 0:
             logging.debug(self.__net_rx_data_paths)
@@ -178,7 +245,12 @@ class NETWORK(Collector):
             self.__rx_metric = Gauge(metric, description, labelnames=labels)
             logging.info(f"--> [registered] {metric} -> {description} (gauge)")
 
-        tx_data_paths = [self.__net_tx_data_paths, self.__cxi_tx_data_paths, self.__ib_tx_data_paths]
+        tx_data_paths = [
+            self.__net_tx_data_paths,
+            self.__cxi_tx_data_paths,
+            self.__ib_tx_data_paths,
+            self.__ainic_tx_data_paths,
+        ]
         num_tx = sum([len(x) for x in tx_data_paths])
         if num_tx > 0:
             logging.debug(self.__net_tx_data_paths)
@@ -241,5 +313,23 @@ class NETWORK(Collector):
                         metric.labels(device_class="infiniband", interface=nic).set(data * 4)
                 except:
                     pass
+
+        # AINIC: hw_counters are already in bytes (no scaling, no timestamp).
+        # rx/tx aggregate unicast + multicast.
+        ainic_data = [
+            (self.__ainic_rx_data_paths, self.__rx_metric),
+            (self.__ainic_tx_data_paths, self.__tx_metric),
+        ]
+
+        for data_paths, metric in ainic_data:
+            for nic, paths in data_paths.items():
+                total = 0
+                for path in paths:
+                    try:
+                        with open(path, "r") as f:
+                            total += int(f.read().strip())
+                    except:
+                        pass
+                metric.labels(device_class="ainic", interface=nic).set(total)
 
         return

--- a/omnistat/collector_network.py
+++ b/omnistat/collector_network.py
@@ -100,6 +100,13 @@ class NETWORK(Collector):
                 "rx_bytes": ["rx_bytes"],
                 "tx_bytes": ["tx_bytes"],
             },
+            "extra_counters": {
+                "rx_packets": ["rx_pkts"],
+                "tx_packets": ["tx_pkts"],
+                "out_of_sequence_packets": ["out_of_sequence"],
+                "rx_discarded_packets": ["rx_roce_discards"],
+                "tx_discarded_packets": ["tx_roce_discards"],
+            },
         },
     }
 

--- a/omnistat/collector_network.py
+++ b/omnistat/collector_network.py
@@ -91,6 +91,8 @@ class NETWORK(Collector):
                 "tx_packets": ["tx_rdma_ucast_pkts", "tx_rdma_mcast_pkts"],
                 "retx_packets": ["tx_rdma_retx_pkts"],
                 "out_of_sequence_packets": ["req_rx_pkt_seq_err"],
+                "ecn_marked_packets": ["rx_rdma_ecn_pkts"],
+                "rx_cnp_packets": ["rx_rdma_cnp_pkts"],
             },
         },
         "bnxt_en": {
@@ -107,8 +109,6 @@ class NETWORK(Collector):
                 "rx_discarded_packets": ["rx_roce_discards"],
                 "tx_discarded_packets": ["tx_roce_discards"],
                 "ecn_marked_packets": ["np_ecn_marked_roce_packets"],
-                "cnp_sent_packets": ["np_cnp_sent"],
-                "cnp_handled_packets": ["rp_cnp_handled"],
             },
         },
     }

--- a/omnistat/collector_network.py
+++ b/omnistat/collector_network.py
@@ -89,8 +89,8 @@ class NETWORK(Collector):
             "extra_counters": {
                 "rx_packets": ["rx_rdma_ucast_pkts", "rx_rdma_mcast_pkts"],
                 "tx_packets": ["tx_rdma_ucast_pkts", "tx_rdma_mcast_pkts"],
-                "retx_packets": ["tx_rdma_retx_pkts"],
-                "out_of_sequence_packets": ["req_rx_pkt_seq_err"],
+                "tx_retransmitted_packets": ["tx_rdma_retx_pkts"],
+                "rx_out_of_sequence_packets": ["req_rx_pkt_seq_err"],
                 "rx_ecn_marked_packets": ["rx_rdma_ecn_pkts"],
                 "rx_cnp_packets": ["rx_rdma_cnp_pkts"],
             },
@@ -107,7 +107,7 @@ class NETWORK(Collector):
             "extra_counters": {
                 "rx_packets": ["rx_pkts"],
                 "tx_packets": ["tx_pkts"],
-                "out_of_sequence_packets": ["out_of_sequence"],
+                "rx_out_of_sequence_packets": ["out_of_sequence"],
                 "rx_discarded_packets": ["rx_roce_discards"],
                 "tx_discarded_packets": ["tx_roce_discards"],
                 "rx_ecn_marked_packets": ["np_ecn_marked_roce_packets"],
@@ -301,7 +301,7 @@ class NETWORK(Collector):
         self.__hw_shared_metrics = {"rx_bytes": self.__rx_metric, "tx_bytes": self.__tx_metric}
 
         # One gauge per extra_counter discovered on any hw_counter NIC, named
-        # after the counter (e.g. rx_packets, retx_packets, out_of_sequence_packets).
+        # after the counter (e.g. rx_packets, tx_retransmitted_packets).
         self.__hw_extra_metrics = {}
         for name in self.__hw_extra_data_paths:
             metric = self.__prefix + name

--- a/omnistat/collector_network.py
+++ b/omnistat/collector_network.py
@@ -106,6 +106,9 @@ class NETWORK(Collector):
                 "out_of_sequence_packets": ["out_of_sequence"],
                 "rx_discarded_packets": ["rx_roce_discards"],
                 "tx_discarded_packets": ["tx_roce_discards"],
+                "ecn_marked_packets": ["np_ecn_marked_roce_packets"],
+                "cnp_sent_packets": ["np_cnp_sent"],
+                "cnp_handled_packets": ["rp_cnp_handled"],
             },
         },
     }

--- a/omnistat/collector_network.py
+++ b/omnistat/collector_network.py
@@ -66,39 +66,43 @@ class NETWORK(Collector):
         self.__ib_rx_data_paths = {}
         self.__ib_tx_data_paths = {}
 
-        # Files to check for AMD AI NIC (AINIC) devices, i.e. AMD Pensando
-        # "ionic" NICs such as Pollara. These appear under
-        # /sys/class/infiniband but do not expose the standard IB port
-        # counters; byte totals live in hw_counters instead. Unicast +
-        # multicast bytes feed the shared rx/tx metrics and capture both
-        # point-to-point RDMA and GPU-collective (RCCL) throughput.
-        self.__ainic_rx_data_paths = {}
-        self.__ainic_tx_data_paths = {}
+        # hw_counter NIC (ainic, thor, ...) byte paths. Value carries the
+        # device_class alongside the list of counter files to sum, e.g.:
+        #   {"bnxt_re0:1": ("thor", [Path(".../hw_counters/rx_bytes")])}
+        self.__hw_rx_data_paths = {}
+        self.__hw_tx_data_paths = {}
 
-    def __is_ainic(self, nic):
-        """Return True if an infiniband-class device is an AMD AI NIC (AINIC).
+    # RoCE-over-Ethernet NICs that appear under /sys/class/infiniband but report
+    # byte totals via hw_counters (already in bytes, no IB octet/4 scaling)
+    # rather than the standard IB port counters. Each is detected by driver
+    # string and feeds the shared rx/tx metrics under its own device_class.
+    _HW_COUNTER_NICS = {
+        "ionic": {  # AMD AINIC (Pensando "ionic", e.g. Pollara)
+            "device_class": "ainic",
+            "rx": ["rx_rdma_ucast_bytes", "rx_rdma_mcast_bytes"],
+            "tx": ["tx_rdma_ucast_bytes", "tx_rdma_mcast_bytes"],
+        },
+        "bnxt_en": {  # Broadcom "Thor" (bnxt_re)
+            "device_class": "thor",
+            "rx": ["rx_bytes"],
+            "tx": ["tx_bytes"],
+        },
+    }
 
-        AINICs (AMD Pensando "ionic" NICs, e.g. Pollara) use the "ionic"
-        driver; detect them via the device's uevent (robust). Fall back to the
-        sysfs signature of empty standard IB counters alongside populated
-        hw_counters if the uevent is unreadable.
+    def __hw_counter_spec(self, nic):
+        """Return the _HW_COUNTER_NICS spec for an infiniband-class device, else None.
+
+        Matched purely on the uevent DRIVER string. A None result means the
+        device is a standard IB NIC and handled by the generic IB branch.
         """
         try:
             uevent = (nic / "device" / "uevent").read_text()
-            for line in uevent.splitlines():
-                if line == "DRIVER=ionic":
-                    return True
-            return False
         except OSError:
-            pass
-
-        # Fallback: no standard IB byte counters, but hw_counters present.
-        for port in (nic / "ports").iterdir():
-            counters = port / "counters" / "port_rcv_data"
-            hw_counters = port / "hw_counters" / "rx_rdma_ucast_bytes"
-            if not counters.is_file() and hw_counters.is_file():
-                return True
-        return False
+            return None
+        for line in uevent.splitlines():
+            if line.startswith("DRIVER="):
+                return self._HW_COUNTER_NICS.get(line[len("DRIVER=") :])
+        return None
 
     def registerMetrics(self):
         """Register metrics of interest"""
@@ -176,16 +180,17 @@ class NETWORK(Collector):
         #       }
         #   }
         #
-        # AMD AI NICs ("ionic" driver, e.g. Pollara) also appear under as
-        # Infiniband but expose bytes via hw_counters instead of the standard
-        # IB counters, so they are detected and handled separately in the
-        # loop below. Their unicast/multicast byte paths are indexed by
-        # interface and port ID. For example, for Rx bandwidth:
-        #   __ainic_rx_data_paths = {
-        #       "ionic_0:1": [
+        # hw_counter NICs ("ionic"/AINIC, "bnxt_en"/Thor, ...) also appear under
+        # Infiniband but expose bytes via hw_counters instead of the standard IB
+        # counters, so they are detected via __hw_counter_spec and handled in a
+        # separate branch below. Their byte paths are indexed by interface and
+        # port ID, with each value carrying the device_class and the list of
+        # counter files to sum. For example, for Rx bandwidth:
+        #   __hw_rx_data_paths = {
+        #       "ionic_0:1": ("ainic", [
         #           "/sys/class/infiniband/ionic_0/ports/1/hw_counters/rx_rdma_ucast_bytes",
         #           "/sys/class/infiniband/ionic_0/ports/1/hw_counters/rx_rdma_mcast_bytes",
-        #       ]
+        #       ]),
         #   }
         ib_base_path = Path("/sys/class/infiniband")
 
@@ -198,21 +203,24 @@ class NETWORK(Collector):
                 continue
 
             ports = nic / "ports"
+            spec = self.__hw_counter_spec(nic)
 
-            if self.__is_ainic(nic):
+            if spec is not None:
+                # hw_counter NIC (ainic, thor): byte totals live in hw_counters
+                # (already in bytes). Claimed here so they never fall through to
+                # the generic IB branch, which would mislabel/double-count them.
+                dclass = spec["device_class"]
                 for port in ports.iterdir():
                     nic_name = f"{nic.name}:{port.name}"
                     hw = port / "hw_counters"
 
-                    rx_ucast = hw / "rx_rdma_ucast_bytes"
-                    rx_mcast = hw / "rx_rdma_mcast_bytes"
-                    if rx_ucast.is_file() and rx_ucast.stat().st_size > 0:
-                        self.__ainic_rx_data_paths[nic_name] = [rx_ucast, rx_mcast]
+                    rx = [hw / c for c in spec["rx"]]
+                    if rx[0].is_file() and rx[0].stat().st_size > 0:
+                        self.__hw_rx_data_paths[nic_name] = (dclass, rx)
 
-                    tx_ucast = hw / "tx_rdma_ucast_bytes"
-                    tx_mcast = hw / "tx_rdma_mcast_bytes"
-                    if tx_ucast.is_file() and tx_ucast.stat().st_size > 0:
-                        self.__ainic_tx_data_paths[nic_name] = [tx_ucast, tx_mcast]
+                    tx = [hw / c for c in spec["tx"]]
+                    if tx[0].is_file() and tx[0].stat().st_size > 0:
+                        self.__hw_tx_data_paths[nic_name] = (dclass, tx)
             else:
                 for port in ports.iterdir():
                     nic_name = f"{nic.name}:{port.name}"
@@ -235,7 +243,7 @@ class NETWORK(Collector):
             self.__net_rx_data_paths,
             self.__cxi_rx_data_paths,
             self.__ib_rx_data_paths,
-            self.__ainic_rx_data_paths,
+            self.__hw_rx_data_paths,
         ]
         num_rx = sum([len(x) for x in rx_data_paths])
         if num_rx > 0:
@@ -249,7 +257,7 @@ class NETWORK(Collector):
             self.__net_tx_data_paths,
             self.__cxi_tx_data_paths,
             self.__ib_tx_data_paths,
-            self.__ainic_tx_data_paths,
+            self.__hw_tx_data_paths,
         ]
         num_tx = sum([len(x) for x in tx_data_paths])
         if num_tx > 0:
@@ -314,15 +322,16 @@ class NETWORK(Collector):
                 except:
                     pass
 
-        # AINIC: hw_counters are already in bytes (no scaling, no timestamp).
-        # rx/tx aggregate unicast + multicast.
-        ainic_data = [
-            (self.__ainic_rx_data_paths, self.__rx_metric),
-            (self.__ainic_tx_data_paths, self.__tx_metric),
+        # hw_counter NICs (ainic, thor): hw_counters are already in bytes (no
+        # scaling); rx/tx sum the per-device counter list. device_class travels
+        # with each interface's paths.
+        hw_data = [
+            (self.__hw_rx_data_paths, self.__rx_metric),
+            (self.__hw_tx_data_paths, self.__tx_metric),
         ]
 
-        for data_paths, metric in ainic_data:
-            for nic, paths in data_paths.items():
+        for data_paths, metric in hw_data:
+            for nic, (dclass, paths) in data_paths.items():
                 total = 0
                 for path in paths:
                     try:
@@ -330,6 +339,6 @@ class NETWORK(Collector):
                             total += int(f.read().strip())
                     except:
                         pass
-                metric.labels(device_class="ainic", interface=nic).set(total)
+                metric.labels(device_class=dclass, interface=nic).set(total)
 
         return

--- a/omnistat/collector_network.py
+++ b/omnistat/collector_network.py
@@ -66,22 +66,22 @@ class NETWORK(Collector):
         self.__ib_rx_data_paths = {}
         self.__ib_tx_data_paths = {}
 
-        # hw_counter NIC (ainic, thor, ...) paths, keyed by counter and
+        # hw_counter NIC (ionic, bnxt_re, ...) paths, keyed by counter and
         # interface, e.g.:
-        #   {"rx_bytes": {"ionic_0:1": ("ainic", [Path(".../rx_rdma_ucast_bytes"), ...])}}
+        #   {"rx_bytes": {"ionic_0:1": ("ionic", [Path(".../rx_rdma_ucast_bytes"), ...])}}
         # shared_counters feed the cross-class rx/tx gauges; extra_counters each
         # get their own hw-only gauge named after the counter.
         self.__hw_shared_data_paths = {}
         self.__hw_extra_data_paths = {}
 
-    # RoCE-over-Ethernet NICs that appear under /sys/class/infiniband but report
-    # byte totals via hw_counters (already in bytes, no IB octet/4 scaling)
-    # rather than the standard IB port counters. Each is detected by driver
-    # string and feeds the shared rx/tx metrics under its own device_class.
+    # RoCE NICs that appear under /sys/class/infiniband but report byte totals
+    # via hw_counters (already in bytes, no IB octet/4 scaling) rather than
+    # the standard IB port counters. Each is detected by driver string and
+    # feeds the shared rx/tx metrics under its own device_class.
     _HW_COUNTER_NICS = {
+        # AMD AINIC (Pensando "ionic", e.g. Pollara)
         "ionic": {
-            # AMD AINIC (Pensando "ionic", e.g. Pollara)
-            "device_class": "ainic",
+            "device_class": "ionic",
             "shared_counters": {
                 "rx_bytes": ["rx_rdma_ucast_bytes", "rx_rdma_mcast_bytes"],
                 "tx_bytes": ["tx_rdma_ucast_bytes", "tx_rdma_mcast_bytes"],
@@ -95,9 +95,11 @@ class NETWORK(Collector):
                 "rx_cnp_packets": ["rx_rdma_cnp_pkts"],
             },
         },
+        # Broadcom "Thor". Detected as bnxt_en, the base Ethernet driver reported
+        # by uevent, but classed as bnxt_re: the RoCE driver layered on top that
+        # owns these hw_counters and names the bnxt_re* interfaces.
         "bnxt_en": {
-            # Broadcom "Thor" (bnxt_re)
-            "device_class": "thor",
+            "device_class": "bnxt_re",
             "shared_counters": {
                 "rx_bytes": ["rx_bytes"],
                 "tx_bytes": ["tx_bytes"],
@@ -213,7 +215,7 @@ class NETWORK(Collector):
         # counter files to sum. For example, for Rx bandwidth:
         #   __hw_shared_data_paths = {
         #       "rx_bytes": {
-        #           "ionic_0:1": ("ainic", [
+        #           "ionic_0:1": ("ionic", [
         #               "/sys/class/infiniband/ionic_0/ports/1/hw_counters/rx_rdma_ucast_bytes",
         #               "/sys/class/infiniband/ionic_0/ports/1/hw_counters/rx_rdma_mcast_bytes",
         #           ]),
@@ -233,7 +235,7 @@ class NETWORK(Collector):
             spec = self.__hw_counter_spec(nic)
 
             if spec is not None:
-                # hw_counter NIC (ainic, thor): byte totals live in hw_counters
+                # hw_counter NIC (ionic, bnxt_re): byte totals live in hw_counters
                 # (already in bytes). Claimed here so they never fall through to
                 # the generic IB branch, which would mislabel/double-count them.
                 dclass = spec["device_class"]
@@ -362,7 +364,7 @@ class NETWORK(Collector):
                 except:
                     pass
 
-        # hw_counter NICs (ainic, thor): hw_counters are already in bytes/packets
+        # hw_counter NICs (ionic, bnxt_re): hw_counters are already in bytes/packets
         # (no scaling); each metric sums its per-device counter list. device_class
         # travels with each interface's paths. shared_counters write the shared
         # rx/tx gauges; extra_counters write their own gauge.

--- a/omnistat/collector_network.py
+++ b/omnistat/collector_network.py
@@ -66,26 +66,40 @@ class NETWORK(Collector):
         self.__ib_rx_data_paths = {}
         self.__ib_tx_data_paths = {}
 
-        # hw_counter NIC (ainic, thor, ...) byte paths. Value carries the
-        # device_class alongside the list of counter files to sum, e.g.:
-        #   {"bnxt_re0:1": ("thor", [Path(".../hw_counters/rx_bytes")])}
-        self.__hw_rx_data_paths = {}
-        self.__hw_tx_data_paths = {}
+        # hw_counter NIC (ainic, thor, ...) paths, keyed by counter and
+        # interface, e.g.:
+        #   {"rx_bytes": {"ionic_0:1": ("ainic", [Path(".../rx_rdma_ucast_bytes"), ...])}}
+        # shared_counters feed the cross-class rx/tx gauges; extra_counters each
+        # get their own hw-only gauge named after the counter.
+        self.__hw_shared_data_paths = {}
+        self.__hw_extra_data_paths = {}
 
     # RoCE-over-Ethernet NICs that appear under /sys/class/infiniband but report
     # byte totals via hw_counters (already in bytes, no IB octet/4 scaling)
     # rather than the standard IB port counters. Each is detected by driver
     # string and feeds the shared rx/tx metrics under its own device_class.
     _HW_COUNTER_NICS = {
-        "ionic": {  # AMD AINIC (Pensando "ionic", e.g. Pollara)
+        "ionic": {
+            # AMD AINIC (Pensando "ionic", e.g. Pollara)
             "device_class": "ainic",
-            "rx": ["rx_rdma_ucast_bytes", "rx_rdma_mcast_bytes"],
-            "tx": ["tx_rdma_ucast_bytes", "tx_rdma_mcast_bytes"],
+            "shared_counters": {
+                "rx_bytes": ["rx_rdma_ucast_bytes", "rx_rdma_mcast_bytes"],
+                "tx_bytes": ["tx_rdma_ucast_bytes", "tx_rdma_mcast_bytes"],
+            },
+            "extra_counters": {
+                "rx_packets": ["rx_rdma_ucast_pkts", "rx_rdma_mcast_pkts"],
+                "tx_packets": ["tx_rdma_ucast_pkts", "tx_rdma_mcast_pkts"],
+                "retx_packets": ["tx_rdma_retx_pkts"],
+                "out_of_sequence_packets": ["req_rx_pkt_seq_err"],
+            },
         },
-        "bnxt_en": {  # Broadcom "Thor" (bnxt_re)
+        "bnxt_en": {
+            # Broadcom "Thor" (bnxt_re)
             "device_class": "thor",
-            "rx": ["rx_bytes"],
-            "tx": ["tx_bytes"],
+            "shared_counters": {
+                "rx_bytes": ["rx_bytes"],
+                "tx_bytes": ["tx_bytes"],
+            },
         },
     }
 
@@ -186,11 +200,13 @@ class NETWORK(Collector):
         # separate branch below. Their byte paths are indexed by interface and
         # port ID, with each value carrying the device_class and the list of
         # counter files to sum. For example, for Rx bandwidth:
-        #   __hw_rx_data_paths = {
-        #       "ionic_0:1": ("ainic", [
-        #           "/sys/class/infiniband/ionic_0/ports/1/hw_counters/rx_rdma_ucast_bytes",
-        #           "/sys/class/infiniband/ionic_0/ports/1/hw_counters/rx_rdma_mcast_bytes",
-        #       ]),
+        #   __hw_shared_data_paths = {
+        #       "rx_bytes": {
+        #           "ionic_0:1": ("ainic", [
+        #               "/sys/class/infiniband/ionic_0/ports/1/hw_counters/rx_rdma_ucast_bytes",
+        #               "/sys/class/infiniband/ionic_0/ports/1/hw_counters/rx_rdma_mcast_bytes",
+        #           ]),
+        #       }
         #   }
         ib_base_path = Path("/sys/class/infiniband")
 
@@ -214,13 +230,14 @@ class NETWORK(Collector):
                     nic_name = f"{nic.name}:{port.name}"
                     hw = port / "hw_counters"
 
-                    rx = [hw / c for c in spec["rx"]]
-                    if rx[0].is_file() and rx[0].stat().st_size > 0:
-                        self.__hw_rx_data_paths[nic_name] = (dclass, rx)
-
-                    tx = [hw / c for c in spec["tx"]]
-                    if tx[0].is_file() and tx[0].stat().st_size > 0:
-                        self.__hw_tx_data_paths[nic_name] = (dclass, tx)
+                    for dest, group in (
+                        (self.__hw_shared_data_paths, spec.get("shared_counters", {})),
+                        (self.__hw_extra_data_paths, spec.get("extra_counters", {})),
+                    ):
+                        for name, counters in group.items():
+                            paths = [hw / c for c in counters]
+                            if paths[0].is_file() and paths[0].stat().st_size > 0:
+                                dest.setdefault(name, {})[nic_name] = (dclass, paths)
             else:
                 for port in ports.iterdir():
                     nic_name = f"{nic.name}:{port.name}"
@@ -243,7 +260,7 @@ class NETWORK(Collector):
             self.__net_rx_data_paths,
             self.__cxi_rx_data_paths,
             self.__ib_rx_data_paths,
-            self.__hw_rx_data_paths,
+            self.__hw_shared_data_paths.get("rx_bytes", {}),
         ]
         num_rx = sum([len(x) for x in rx_data_paths])
         if num_rx > 0:
@@ -257,7 +274,7 @@ class NETWORK(Collector):
             self.__net_tx_data_paths,
             self.__cxi_tx_data_paths,
             self.__ib_tx_data_paths,
-            self.__hw_tx_data_paths,
+            self.__hw_shared_data_paths.get("tx_bytes", {}),
         ]
         num_tx = sum([len(x) for x in tx_data_paths])
         if num_tx > 0:
@@ -265,6 +282,18 @@ class NETWORK(Collector):
             metric = self.__prefix + "tx_bytes"
             description = "Network transmitted (bytes)"
             self.__tx_metric = Gauge(metric, description, labelnames=labels)
+            logging.info(f"--> [registered] {metric} -> {description} (gauge)")
+
+        # shared_counters map to the pre-existing cross-class gauges above.
+        self.__hw_shared_metrics = {"rx_bytes": self.__rx_metric, "tx_bytes": self.__tx_metric}
+
+        # One gauge per extra_counter discovered on any hw_counter NIC, named
+        # after the counter (e.g. rx_packets, retx_packets, out_of_sequence_packets).
+        self.__hw_extra_metrics = {}
+        for name in self.__hw_extra_data_paths:
+            metric = self.__prefix + name
+            description = f"Network {name.replace('_', ' ')}"
+            self.__hw_extra_metrics[name] = Gauge(metric, description, labelnames=labels)
             logging.info(f"--> [registered] {metric} -> {description} (gauge)")
 
     def updateMetrics(self):
@@ -322,23 +351,26 @@ class NETWORK(Collector):
                 except:
                     pass
 
-        # hw_counter NICs (ainic, thor): hw_counters are already in bytes (no
-        # scaling); rx/tx sum the per-device counter list. device_class travels
-        # with each interface's paths.
-        hw_data = [
-            (self.__hw_rx_data_paths, self.__rx_metric),
-            (self.__hw_tx_data_paths, self.__tx_metric),
+        # hw_counter NICs (ainic, thor): hw_counters are already in bytes/packets
+        # (no scaling); each metric sums its per-device counter list. device_class
+        # travels with each interface's paths. shared_counters write the shared
+        # rx/tx gauges; extra_counters write their own gauge.
+        hw_metrics = [
+            (self.__hw_shared_data_paths, self.__hw_shared_metrics),
+            (self.__hw_extra_data_paths, self.__hw_extra_metrics),
         ]
 
-        for data_paths, metric in hw_data:
-            for nic, (dclass, paths) in data_paths.items():
-                total = 0
-                for path in paths:
-                    try:
-                        with open(path, "r") as f:
-                            total += int(f.read().strip())
-                    except:
-                        pass
-                metric.labels(device_class=dclass, interface=nic).set(total)
+        for data_paths, metrics in hw_metrics:
+            for name, interfaces in data_paths.items():
+                metric = metrics[name]
+                for nic, (dclass, paths) in interfaces.items():
+                    total = 0
+                    for path in paths:
+                        try:
+                            with open(path, "r") as f:
+                                total += int(f.read().strip())
+                        except:
+                            pass
+                    metric.labels(device_class=dclass, interface=nic).set(total)
 
         return

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -105,7 +105,7 @@ ROCPROFILER_METRICS = [
 ]
 
 # Network metrics are hardware-dependent (specific device classes such as
-# "cxi" or "ainic" only appear on matching NICs), so assertions stay generic:
+# "cxi" or "ionic" only appear on matching NICs), so assertions stay generic:
 # any host with a non-loopback interface exposes rx/tx byte totals.
 NETWORK_METRICS = [
     {"name": "omnistat_network_rx_bytes",                    "validate": ">=0",               "labels": ["device_class", "interface"]},

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -104,6 +104,14 @@ ROCPROFILER_METRICS = [
     {"name": "omnistat_hardware_counter",                    "validate": ">=0",               "labels": ["source", "card", "name"]},
 ]
 
+# Network metrics are hardware-dependent (specific device classes such as
+# "cxi" or "ainic" only appear on matching NICs), so assertions stay generic:
+# any host with a non-loopback interface exposes rx/tx byte totals.
+NETWORK_METRICS = [
+    {"name": "omnistat_network_rx_bytes",                    "validate": ">=0",               "labels": ["device_class", "interface"]},
+    {"name": "omnistat_network_tx_bytes",                    "validate": ">=0",               "labels": ["device_class", "interface"]},
+]
+
 # fmt: on
 
 
@@ -178,6 +186,10 @@ COLLECTOR_CONFIGS = [
     {
         "collectors": ["host_metrics", "omnistat.collectors.host::enable_proc_io_stats"],
         "metrics": HOST_METRICS,
+    },
+    {
+        "collectors": ["network"],
+        "metrics": NETWORK_METRICS,
     },
     {
         "collectors": ["rocprofiler"],


### PR DESCRIPTION
## Summary

Extend the network data collector to cover RoCE NIC families that report metrics via `hw_counters` under `/sys/class/infiniband` rather than the standard IB port counters, and add test coverage for network metrics. Two additional NIC families are now supported alongside Ethernet/IB/Slingshot:

- **ionic** — AMD Pensando AINICs (e.g. Pollara)
- **bnxt_re** — Broadcom Thor NICs

Both are detected by driver string and reported under a distinct `device_class` label.

## Changes

- **Test presence of network metrics** — assert `omnistat_network_rx_bytes`/`tx_bytes` are exposed with `device_class`/`interface` labels; assertions stay generic since device classes only appear on matching hardware.
- **Support AINIC rx/tx metrics** — detect `ionic` NICs; sum unicast + multicast `hw_counters` bytes.
- **Support Thor (bnxt_re) rx/tx metrics** — detect `bnxt_en` NICs; report `hw_counters` `rx_bytes`/`tx_bytes`.
- **Add per-packet and fabric-health metrics** (packets, out-of-sequence, retransmit/discards, ECN/CNP) for AINIC and Thor.

| Metric | AINIC (`ionic`) | Thor (`bnxt_re`) | Source counter(s) |
|---|:---:|:---:|---|
| `omnistat_network_rx_bytes` | ✓ | ✓ | AINIC: `rx_rdma_{ucast,mcast}_bytes` · Thor: `rx_bytes` |
| `omnistat_network_tx_bytes` | ✓ | ✓ | AINIC: `tx_rdma_{ucast,mcast}_bytes` · Thor: `tx_bytes` |
| `omnistat_network_rx_packets` | ✓ | ✓ | AINIC: `rx_rdma_{ucast,mcast}_pkts` · Thor: `rx_pkts` |
| `omnistat_network_tx_packets` | ✓ | ✓ | AINIC: `tx_rdma_{ucast,mcast}_pkts` · Thor: `tx_pkts` |
| `omnistat_network_rx_out_of_sequence_packets` | ✓ | ✓ | AINIC: `req_rx_pkt_seq_err` · Thor: `out_of_sequence` |
| `omnistat_network_tx_retransmitted_packets` | ✓ | — | AINIC: `tx_rdma_retx_pkts` |
| `omnistat_network_rx_discarded_packets` | — | ✓ | Thor: `rx_roce_discards` |
| `omnistat_network_tx_discarded_packets` | — | ✓ | Thor: `tx_roce_discards` |
| `omnistat_network_rx_ecn_marked_packets` | ✓ | ✓ | AINIC: `rx_rdma_ecn_pkts` · Thor: `np_ecn_marked_roce_packets` |
| `omnistat_network_rx_cnp_packets` | ✓ | ✓ | AINIC: `rx_rdma_cnp_pkts` · Thor: `rp_cnp_handled` + `rp_cnp_ignored` |


## Verification performed

All exercised on real hardware (AMD Instinct MI355X nodes with 8x AINIC or Thor NICs):

- [x] Counter semantics confirmed with a controlled `ib_write_bw` loopback.
- [x] AINIC RCCL attribution confirmed via a controlled 2-node all-reduce: `ucast_bytes` grew by +26.06 GB on every NIC per node; `ccl_cts` stayed at 0, validating that `rx/tx_bytes` captures collective throughput and justifying the `ccl_cts` exclusion.
- [x] Collector runs end-to-end on hardware: instantiated `NETWORK`, scraped metrics, saw samples emitted.
- [x] Congestion probe: a single-rail RCCL funnel increased health metrics.
- [x] `pytest test/test_collectors.py -k network` on a node with these NICs

### Notes / decisions

- **No Grafana dashboard changes.** The dashboards already split Ethernet (`device_class="net"`) from "High Performance Interconnect" (`device_class!="net"`), so AINIC traffic is captured automatically.
- For AINICs, **`ccl_cts` counters were intentionally excluded.** A controlled 2-node RCCL run showed collective traffic is counted in `ucast_bytes`, while `ccl_cts` is a low-volume, fixed-24-byte, tx==rx-symmetric control/credit channel (unchanged by both point-to-point RDMA and RCCL collectives), not throughput worth surfacing.

### Future work: virtualized / logical network view

- Dashboard updates for network health metrics.
- All testing so far has been on **bare metal**, where each AINIC maps to a single physical function under `/sys/class/infiniband`. The virtualized topology has not been validated.