### PR TITLE
Switch kernel tracing from libcurl to cpp-httplib

### DIFF
--- a/docs/installation/extensions.md
+++ b/docs/installation/extensions.md
@@ -56,15 +56,19 @@ extension above, it does not require a Python build step.
 ### Requirements
 
 - ROCm 6.4+
-- libcurl
 - C++20 compiler
 - CMake 3.15+
 
 ```{note}
-If the compiler does not support `std::format`, the build automatically fetches the [fmt](https://github.com/fmtlib/fmt) library via CMake's `FetchContent`.
-For offline builds, download the fmt source tree ahead of time and point CMake at it:
+The build automatically fetches the header-only
+[cpp-httplib](https://github.com/yhirose/cpp-httplib) library (used to send
+trace data over HTTP) via CMake's `FetchContent`, along with the
+[fmt](https://github.com/fmtlib/fmt) library if the compiler does not support
+`std::format`. For offline builds, download the source trees ahead of time and
+point CMake at them:
 
     cmake -S rocprofiler-sdk/ -B build-trace/ -DBUILD_KERNEL_TRACE_LIB=ON \
+      -DFETCHCONTENT_SOURCE_DIR_HTTPLIB=/path/to/cpp-httplib \
       -DFETCHCONTENT_SOURCE_DIR_FMT=/path/to/fmt
 ```
 

--- a/rocprofiler-sdk/CMakeLists.txt
+++ b/rocprofiler-sdk/CMakeLists.txt
@@ -49,14 +49,23 @@ if (NOT BUILD_KERNEL_TRACE_LIB)
     install(TARGETS rocprofiler_sdk_extension LIBRARY DESTINATION omnistat)
 else()
     find_package(rocprofiler-sdk REQUIRED)
-    find_package(CURL REQUIRED)
 
     include(FetchContent)
     include(CheckCXXSourceCompiles)
 
+    # Header-only HTTP client. Fetched at configure time; for offline builds,
+    # download the source tree and point CMake at it:
+    #   -DFETCHCONTENT_SOURCE_DIR_HTTPLIB=/path/to/cpp-httplib
+    FetchContent_Declare(
+        httplib
+        URL https://github.com/yhirose/cpp-httplib/archive/refs/tags/v0.18.3.tar.gz
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+    FetchContent_MakeAvailable(httplib)
+
     add_library(omnistat_trace SHARED kernel_tracer.cpp)
     target_compile_features(omnistat_trace PRIVATE cxx_std_20)
-    target_link_libraries(omnistat_trace PRIVATE rocprofiler-sdk::rocprofiler-sdk CURL::libcurl)
+    target_link_libraries(omnistat_trace PRIVATE rocprofiler-sdk::rocprofiler-sdk httplib::httplib)
 
     # Check if the compiler supports std::format
     set(CMAKE_REQUIRED_FLAGS "-std=c++20")

--- a/rocprofiler-sdk/CMakeLists.txt
+++ b/rocprofiler-sdk/CMakeLists.txt
@@ -25,6 +25,13 @@
 cmake_minimum_required(VERSION 3.15)
 project(omnistat_rocprofiler_sdk_extension LANGUAGES CXX)
 
+# Default to an optimized build. The kernel tracer's flush() path (including the
+# header-only HTTP client compiled into this library) is performance-sensitive,
+# so an unoptimized default would ship a needlessly slow library.
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+endif()
+
 # The kernel tracing library is meant to be built separately from the Omnistat
 # package and extensions. When it's enabled, compile only the library and
 # nothing else.

--- a/rocprofiler-sdk/README.md
+++ b/rocprofiler-sdk/README.md
@@ -90,11 +90,11 @@ kernel dispatches and streams the data to omnistat-standalone via HTTP.
 ### Requirements
 
 - ROCm 6.4+ with ROCProfiler-SDK
-- libcurl
 - C++20 compiler (GCC 13+ or Clang 16+)
 - CMake 3.15+
 
-CMake automatically fetches the `fmt` library if the compiler lacks
+CMake automatically fetches the header-only `cpp-httplib` library (used to send
+trace data over HTTP), and the `fmt` library if the compiler lacks
 `std::format`.
 
 ### Building

--- a/rocprofiler-sdk/kernel_tracer.cpp
+++ b/rocprofiler-sdk/kernel_tracer.cpp
@@ -56,10 +56,6 @@ static std::string demangle(const char* mangled_name) {
     return (status == 0) ? result.get() : mangled_name;
 }
 
-static size_t write_callback(char* ptr, size_t size, size_t nmemb, void* userdata) {
-    return size * nmemb;
-}
-
 // Callback used to register kernels when loading code objects. Forces a flush
 // on every kernel unload; the expectation is that only happens at the end of
 // the application and it's only triggered once for the first kernel unload.
@@ -136,20 +132,12 @@ KernelTracer::KernelTracer()
 }
 
 int KernelTracer::initialize() {
-    curl_global_init(CURL_GLOBAL_ALL);
-
-    curl_handle_ = curl_easy_init();
-    if (!curl_handle_) {
-        std::cerr << "Omnistat: failed to initialize libcurl" << std::endl;
+    client_ = std::make_unique<httplib::Client>("localhost", static_cast<int>(endpoint_port_));
+    if (!client_) {
+        std::cerr << "Omnistat: failed to initialize HTTP client" << std::endl;
         return -1;
     }
-
-    std::string url = fmt::format("http://localhost:{}/kernel_trace", endpoint_port_);
-    curl_easy_setopt(curl_handle_, CURLOPT_URL, url.c_str());
-    struct curl_slist* http_headers = NULL;
-    http_headers = curl_slist_append(http_headers, "Content-Type: application/json");
-    curl_easy_setopt(curl_handle_, CURLOPT_HTTPHEADER, http_headers);
-    curl_easy_setopt(curl_handle_, CURLOPT_WRITEFUNCTION, &omnistat::write_callback);
+    client_->set_keep_alive(true);
 
     agents = omnistat::build_agent_map();
 
@@ -223,30 +211,13 @@ KernelTracer::~KernelTracer() {
                       << total_flushes_ << " successful flushes)" << std::endl;
         }
     }
-
-    if (curl_handle_) {
-        curl_easy_cleanup(curl_handle_);
-    }
 }
 
 bool KernelTracer::flush(std::string_view data, size_t num_records) {
     record_flush_time();
 
-    curl_easy_setopt(curl_handle_, CURLOPT_POST, 1L);
-    curl_easy_setopt(curl_handle_, CURLOPT_POSTFIELDSIZE, static_cast<long>(data.size()));
-    curl_easy_setopt(curl_handle_, CURLOPT_POSTFIELDS, data.data());
-
-    std::string response_buffer;
-    curl_easy_setopt(curl_handle_, CURLOPT_WRITEDATA, &response_buffer);
-
-    CURLcode res = curl_easy_perform(curl_handle_);
-
-    bool success = false;
-    if (res == CURLE_OK) {
-        long http_code = 0;
-        curl_easy_getinfo(curl_handle_, CURLINFO_RESPONSE_CODE, &http_code);
-        success = http_code < 400;
-    }
+    auto res = client_->Post(path_, std::string(data), "application/json");
+    bool success = res && res->status < 400;
 
     record_flush_stats(num_records, !success);
     return success;

--- a/rocprofiler-sdk/kernel_tracer.hpp
+++ b/rocprofiler-sdk/kernel_tracer.hpp
@@ -26,10 +26,11 @@
 
 #include <rocprofiler-sdk/rocprofiler.h>
 
-#include <curl/curl.h>
+#include <httplib.h>
 
 #include <atomic>
 #include <condition_variable>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -89,8 +90,9 @@ class KernelTracer {
     std::atomic<uint64_t> failed_flushes_{0};
     std::atomic<uint64_t> failed_records_{0};
 
-    // libcurl handle for sending trace data
-    CURL* curl_handle_ = nullptr;
+    // HTTP client and endpoint path for sending trace data
+    std::unique_ptr<httplib::Client> client_;
+    std::string path_ = "/kernel_trace";
 };
 
 } // namespace omnistat


### PR DESCRIPTION
**Summary**

  - Replace libcurl with the header-only cpp-httplib (https://github.com/yhirose/cpp-httplib) in the kernel-tracing library (libomnistat_trace.so), removing a fragile shared-library runtime dependency that broke
  when libcurl was missing or ABI-mismatched in the execution environment.
  - Fetch cpp-httplib at configure time via CMake FetchContent, mirroring the existing fmt handling. No TLS needed — traffic is plain HTTP to localhost.
  - Default `CMAKE_BUILD_TYPE` to Release when unset; the library previously shipped unoptimized (-O0), which matters since `flush()` is on the hot path.

  **Performance**

  Benchmarked curl vs cpp-httplib on MI300 (mi3001x), both at -O3, across 1k–100k kernel dispatches: wall-clock is equivalent (e.g. 100k: 1306ms curl vs 1302ms httplib) with zero dropped records in all cases.
