### PR TITLE
Warn when performance counter privileges are insufficient

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -250,10 +250,13 @@ Each profile defines a sampling mode and a set of counters to be collected:
 The ROCprofiler data collector requires [building the hardware counters
 extension](./installation/extensions.md#hardware-counters).
 
-To ensure all performance counters are collected correctly, the collector has
-the following requirements depending on how Omnistat is executed:
+To ensure all performance counters are collected correctly, the collector needs
+performance monitoring privileges, with requirements depending on how Omnistat
+is executed:
 - *System mode*: Run Omnistat with the `CAP_PERFMON` capability enabled.
-- *User mode*: Set the `HSA_TOOLS_LIB` environment variable in the application's runtime environment.
+- *User mode*: `/proc/sys/kernel/perf_event_paranoid` must be `2` or less (some
+  distributions default to `4`), and the following environment variables must be
+  set in the application's environment:
   ```shell
   export HSA_TOOLS_LIB=/opt/rocm/lib/librocprofiler64.so
   export HSA_TOOLS_ROCPROFILER_V1_TOOLS=1

--- a/omnistat/collector_rocprofiler_sdk.py
+++ b/omnistat/collector_rocprofiler_sdk.py
@@ -41,6 +41,7 @@ omnistat_hardware_counter{source="gpu",card="0",name="TA_BUSY_avr"} 0.0
 import json
 import logging
 import os
+import re
 import sys
 
 from prometheus_client import Gauge, generate_latest
@@ -54,6 +55,13 @@ except ModuleNotFoundError as e:
     sys.exit(4)
 
 SAMPLING_MODES = ["constant", "gpu-id", "periodic"]
+
+# Counter collection requires performance monitoring privileges, granted either by
+# the CAP_PERFMON (38) or CAP_SYS_ADMIN (21) capabilities, or by a paranoid setting
+# of 2 or less.
+PERF_EVENT_PARANOID_PATH = "/proc/sys/kernel/perf_event_paranoid"
+PERF_EVENT_PARANOID_MAX = 2
+PERF_CAPABILITY_MASK = (1 << 38) | (1 << 21)
 
 initialize()
 
@@ -114,6 +122,16 @@ class rocprofiler_sdk(Collector):
         if mode == "gpu-id" and len(counters) == 1:
             logging.error('ERROR: "gpu-id" sampling mode requires multiple sets of counters')
             sys.exit(4)
+
+        try:
+            paranoid = int(open(PERF_EVENT_PARANOID_PATH).read())
+            caps = int(re.search(r"CapEff:\s*(\S+)", open("/proc/self/status").read()).group(1), 16)
+            if paranoid > PERF_EVENT_PARANOID_MAX and not caps & PERF_CAPABILITY_MASK:
+                logging.warning("WARNING: Insufficient privileges for performance counter collection")
+                logging.warning(f"--> {PERF_EVENT_PARANOID_PATH} = {paranoid}, some counters may be unavailable")
+                logging.warning(f"--> requires CAP_PERFMON, or a value of {PERF_EVENT_PARANOID_MAX} or less")
+        except (OSError, ValueError, AttributeError):
+            pass
 
         self.__samplers = get_samplers()
         self.__mode = mode


### PR DESCRIPTION
  Hardware counter collection needs performance monitoring privileges, granted   either by `CAP_PERFMON`/`CAP_SYS_ADMIN` or by a `perf_event_paranoid` setting of   2 or less. Some distributions default to 4, which silently limits the counters   that can be collected.

The rocprofiler-sdk collector now warns at initialization when neither is   present:

```
WARNING: Insufficient privileges for performance counter collection
--> /proc/sys/kernel/perf_event_paranoid = 4, some counters may be unavailable
--> requires CAP_PERFMON, or a value of 2 or less
```

Docs updated to list the requirement per execution mode.