### PR TITLE
add GPU serial number tracking

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -42,7 +42,7 @@ health and performance.
 
 | GPU Metric                        | Description                          |
 | :-------------------------------- | :----------------------------------- |
-| `rocm_version_info`               | GPU model and versioning information for GPU driver and VBIOS. Labels: `driver_ver`, `vbios`, `type`, `schema`. |
+| `rocm_version_info`               | GPU model and versioning information for GPU driver and VBIOS. Labels: `driver_ver`, `vbios`, `type`, `serial`. |
 | `rocm_utilization_percentage`     | GPU utilization (%). |
 | `rocm_vram_used_percentage`       | Memory utilization (%). |
 | `rocm_vram_total_bytes`           | Total GPU memory (bytes). |

--- a/omnistat/collector_amdsmi.py
+++ b/omnistat/collector_amdsmi.py
@@ -189,7 +189,11 @@ class AMDSMI(Collector):
             vbios = vbios_info["part_number"]
             asic_info = smi.amdsmi_get_gpu_asic_info(device)
             devtype = asic_info["market_name"]
-            serial = asic_info.get("asic_serial", "")
+            try:
+                board_info = smi.amdsmi_get_gpu_board_info(device)
+                serial = board_info.get("product_serial", "")
+            except Exception:
+                serial = ""
 
             driver_info = smi.amdsmi_get_gpu_driver_info(device)
             gpuDriverVer = driver_info["driver_version"]

--- a/omnistat/collector_amdsmi.py
+++ b/omnistat/collector_amdsmi.py
@@ -180,7 +180,7 @@ class AMDSMI(Collector):
         version_metric = Gauge(
             self.__prefix + "version_info",
             "GPU versioning information",
-            labelnames=["card", "driver_ver", "vbios", "type"],
+            labelnames=["card", "driver_ver", "vbios", "type", "serial"],
         )
 
         for idx, device in enumerate(self.__devices):
@@ -189,11 +189,12 @@ class AMDSMI(Collector):
             vbios = vbios_info["part_number"]
             asic_info = smi.amdsmi_get_gpu_asic_info(device)
             devtype = asic_info["market_name"]
+            serial = asic_info.get("asic_serial", "")
 
             driver_info = smi.amdsmi_get_gpu_driver_info(device)
             gpuDriverVer = driver_info["driver_version"]
 
-            version_metric.labels(card=gpuLabel, driver_ver=gpuDriverVer, vbios=vbios, type=devtype).set(1)
+            version_metric.labels(card=gpuLabel, driver_ver=gpuDriverVer, vbios=vbios, type=devtype, serial=serial).set(1)
 
         # Register memory related metrics
         self.__GPUMetrics["vram_total_bytes"] = Gauge(

--- a/omnistat/collector_amdsmi.py
+++ b/omnistat/collector_amdsmi.py
@@ -198,7 +198,9 @@ class AMDSMI(Collector):
             driver_info = smi.amdsmi_get_gpu_driver_info(device)
             gpuDriverVer = driver_info["driver_version"]
 
-            version_metric.labels(card=gpuLabel, driver_ver=gpuDriverVer, vbios=vbios, type=devtype, serial=serial).set(1)
+            version_metric.labels(card=gpuLabel, driver_ver=gpuDriverVer, vbios=vbios, type=devtype, serial=serial).set(
+                1
+            )
 
         # Register memory related metrics
         self.__GPUMetrics["vram_total_bytes"] = Gauge(

--- a/omnistat/collector_rocmsmi.py
+++ b/omnistat/collector_rocmsmi.py
@@ -299,7 +299,7 @@ class ROCMSMI(Collector):
         version_metric = Gauge(
             self.__prefix + "version_info",
             "GPU versioning information",
-            labelnames=["card", "driver_ver", "vbios", "type"],
+            labelnames=["card", "driver_ver", "vbios", "type", "serial"],
         )
         for i in range(self.__num_gpus):
             gpuLabel = self.__indexMapping[i]
@@ -312,11 +312,19 @@ class ROCMSMI(Collector):
             self.__libsmi.rsmi_dev_name_get(device, ver_str, 256)
             devtype = ver_str.value.decode()
 
+            serial = ""
+            try:
+                self.__libsmi.rsmi_dev_serial_number_get(device, ver_str, 256)
+                serial = ver_str.value.decode().strip()
+            except Exception:
+                pass
+
             version_metric.labels(
                 card=gpuLabel,
                 driver_ver=self.__gpuDriverVer,
                 vbios=vbios,
                 type=devtype,
+                serial=serial,
             ).set(1)
 
         # register desired metric names

--- a/test/test_collectors.py
+++ b/test/test_collectors.py
@@ -45,7 +45,7 @@ from omnistat.utils import runShellCommand
 # fmt: off
 SMI_METRICS = [
     {"name":"rocm_num_gpus",                                "validate":">=1",                "labels":None},
-    {"name":"rocm_version_info",                            "validate":"==1.0",              "labels":["card","driver_ver","type"]},
+    {"name":"rocm_version_info",                            "validate":"==1.0",              "labels":["card","driver_ver","serial","type"]},
     {"name":"rocm_temperature_celsius",                     "validate":">=10",               "labels":["card","location"]},
     {"name":"rocm_temperature_memory_celsius",              "validate":">=10",               "labels":["card","location"]},
     {"name":"rocm_average_socket_power_watts",              "validate":">=10",               "labels":["card"]},


### PR DESCRIPTION
This PR updates the SMI data collectors to include a new `serial` label in the existing `rocm_version_info` metric.  This allows for additional inventory tracking of specific GPUs and their host location.  Examples of the updated metric from a MI210 host is as follows:

```
rocm_version_info{card="3",driver_ver="6.16.13",serial="xxxxx00064xx",type="AMD Instinct MI210",vbios="113-D67301V-073"} 1.0
rocm_version_info{card="2",driver_ver="6.16.13",serial="xxxxx90106xx",type="AMD Instinct MI210",vbios="113-D67301V-073"} 1.0
57rocm_version_info{card="1",driver_ver="6.16.13",serial="xxxxx20013xx",type="AMD Instinct MI210",vbios="113-D67301V-073"} 1.0
3rocm_version_info{card="0",driver_ver="6.16.13",serial="xxxxx40003xx",type="AMD Instinct MI210",vbios="113-D67301V-073"} 1.0
```

Note that the data maps to values shown by `rocm-smi --showserial` or `amd-smi static`.  For example:

```
$ amd-smi static | grep -i product_serial
        PRODUCT_SERIAL: xxxxx00064xx
        PRODUCT_SERIAL: xxxxx90106xx
        PRODUCT_SERIAL: xxxxx20013xx
        PRODUCT_SERIAL: xxxxx40003xx
```

